### PR TITLE
Bump numpy from 2.1.1 to 2.1.2 in the python-packages group

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -9,4 +9,4 @@ protobuf==5.28.2
 requests==2.32.3
 Werkzeug==3.0.4
 paho-mqtt==2.1.0
-numpy==2.1.1
+numpy==2.1.2


### PR DESCRIPTION
Bumps the python-packages group with 1 update: [numpy](https://github.com/numpy/numpy).


Updates `numpy` from 2.1.1 to 2.1.2
- [Release notes](https://github.com/numpy/numpy/releases)
- [Changelog](https://github.com/numpy/numpy/blob/main/doc/RELEASE_WALKTHROUGH.rst)
- [Commits](https://github.com/numpy/numpy/compare/v2.1.1...v2.1.2)

---
updated-dependencies:
- dependency-name: numpy dependency-type: direct:production update-type: version-update:semver-patch dependency-group: python-packages ...