### PR TITLE
Fix ARM64 and update python packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,8 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
     wget \
-    unattended-upgrades 
-
-RUN wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-RUN apt-get install -y ./google-chrome-stable_current_amd64.deb \
+    unattended-upgrades \
+    chromium-driver \
     && rm -rf /var/lib/apt/lists/*
 
 ARG USERNAME=inkplate

--- a/server/README.md
+++ b/server/README.md
@@ -77,7 +77,7 @@ python3 --version
 Python 3.11.2
 ```
 
-Download project and install dependencies
+Download project and install dependencies.  The default main branch is the latest stable branch.  The next branch contains changes planned for the next release - it should be OK to use.  But might not be.
 ```
 git clone https://github.com/OrangeSpyderMan/inkplate10-weather-cal
 cd inkplate10-weather-cal

--- a/server/views/page.py
+++ b/server/views/page.py
@@ -6,7 +6,7 @@ from airium import Airium
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.common.exceptions import WebDriverException
-
+from selenium.webdriver.chrome.service import Service
 
 class Page:
     def __init__(
@@ -63,7 +63,8 @@ class Page:
 
         driver = None
         try:
-             driver = webdriver.Chrome(options=opts)
+             chrome_path = Service(executable_path = r"/usr/bin/chromedriver")
+             driver = webdriver.Chrome(service=chrome_path , options=opts)
         except WebDriverException as wde:
              raise wde 
 


### PR DESCRIPTION
This reverts to the Debian chromium-driver package (having previously changed to use the Google Chrome .deb release).  This is mainly to support native running on ARM64, and it changes the way the chromium-driver is called to remove the dependency on Selenium-manager (which isn't supported on ARM64, AFAICT)

Also bumps a couple of Python packages.