### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,5 +1,8 @@
 name: Docker Image CI
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/OrangeSpyderMan/inkplate10-weather-cal/security/code-scanning/1](https://github.com/OrangeSpyderMan/inkplate10-weather-cal/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow. Since the workflow only checks out the repository and builds a Docker image, it does not require write access. The `permissions` block should be added at the root level of the workflow to apply to all jobs. The minimal permissions required are `contents: read`, which allows the workflow to read the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
