### PR TITLE
Publish OCI container images for main and next

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+WEATHER_API_KEY=replace-with-weather-api-key
+GOOGLE_API_KEY=replace-with-google-api-key
+GOOGLE_STATICMAPS_MAPID=replace-with-google-staticmaps-map-id
+
+# Optional, only when current_temperature.source is netatmo
+NETATMO_CLIENT_ID=
+NETATMO_CLIENT_SECRET=
+NETATMO_REFRESH_TOKEN=
+NETATMO_DEVICE_ID=
+NETATMO_MODULE_ID=

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -1,0 +1,74 @@
+name: Publish Container Image
+
+on:
+  push:
+    branches:
+      - main
+      - next
+    tags:
+      - "v*"
+    paths:
+      - "server/**"
+      - "Dockerfile"
+      - "docker-compose.yml"
+      - ".dockerignore"
+      - ".github/workflows/container-publish.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/orangespyderman/inkplate10-weather-cal
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' || startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=next,enable=${{ github.ref == 'refs/heads/next' }}
+            type=ref,event=tag
+            type=sha,prefix=sha-
+
+      - name: Generate build date
+        id: build-date
+        run: echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_DATE=${{ steps.build-date.outputs.created }}
+            VCS_REF=${{ github.sha }}
+            VERSION=${{ github.ref_name }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,12 +10,16 @@ on:
       - 'Dockerfile'
       - 'docker-compose.yml'
       - '.dockerignore'
+      - '.env.example'
+      - '.github/workflows/docker-image.yml'
   pull_request:
     paths:
       - 'server/**'
       - 'Dockerfile'
       - 'docker-compose.yml'
       - '.dockerignore'
+      - '.env.example'
+      - '.github/workflows/docker-image.yml'
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,18 @@
 FROM python:3.13-slim-bookworm
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+
+LABEL org.opencontainers.image.title="Inkplate 10 Weather Calendar" \
+    org.opencontainers.image.description="Server renderer for the Inkplate 10 weather calendar" \
+    org.opencontainers.image.url="https://github.com/OrangeSpyderMan/inkplate10-weather-cal" \
+    org.opencontainers.image.source="https://github.com/OrangeSpyderMan/inkplate10-weather-cal" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.created="${BUILD_DATE}" \
+    org.opencontainers.image.revision="${VCS_REF}" \
+    org.opencontainers.image.version="${VERSION}"
+
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1

--- a/server/README.md
+++ b/server/README.md
@@ -230,6 +230,12 @@ Create a local `.env` file in the repository root. Docker Compose reads this
 file and passes the values into the container:
 
 ```bash
+cp .env.example .env
+```
+
+Then edit `.env`:
+
+```bash
 WEATHER_API_KEY=...
 GOOGLE_API_KEY=...
 GOOGLE_STATICMAPS_MAPID=...
@@ -246,6 +252,16 @@ The compose file mounts `server/config.yaml` read-only and stores mutable
 runtime data in the named `inkplate-data` volume. The Docker example sets the
 Netatmo token file to `data/netatmo-token.json` so refreshed tokens survive
 container replacement.
+
+The published OCI images are:
+
+```text
+ghcr.io/orangespyderman/inkplate10-weather-cal:main
+ghcr.io/orangespyderman/inkplate10-weather-cal:next
+```
+
+Use `:main` for stable deployments. Use `:next` to test changes before they are
+promoted to `main`.
 
 Do not commit `server/config.yaml` or `.env`; keep API keys and refresh tokens
 in local files or runtime environment variables.
@@ -270,6 +286,13 @@ Or detach it:
 docker compose up --build -d
 ```
 
+To use the published image instead of building locally, replace the Compose
+service `build:` block with:
+
+```yaml
+image: ghcr.io/orangespyderman/inkplate10-weather-cal:main
+```
+
 The server listens on port `8080` and serves the generated image from:
 
 ```text
@@ -287,3 +310,60 @@ run the MQTT broker as another Compose service or use the host's LAN IP.
 There is a sample crontab called [docker-errorlog](docker-errorlog) that can be
 used to check the Docker logs for ERROR messages. By default that runs every
 hour, on the hour, but may need local tweaking.
+
+## Running from a Published OCI Image
+
+The image is a normal OCI image and can be run by Docker, Podman, or platforms
+that consume OCI images directly.
+
+Example Podman/Docker run:
+
+```bash
+podman run -d \
+  --name inkplate-weather-cal \
+  --env-file .env \
+  -p 8080:8080 \
+  -v ./server/config.yaml:/srv/inkplate/server/config.yaml:ro \
+  -v inkplate-data:/srv/inkplate/server/data \
+  ghcr.io/orangespyderman/inkplate10-weather-cal:main
+```
+
+Use `docker run` with the same arguments if you prefer Docker.
+
+### Proxmox VE 9.1 OCI LXC
+
+Proxmox VE 9.1 can create LXC containers from OCI images. This image should be
+usable as an OCI source, but treat this as newer and less tested than Docker
+Compose until it has been exercised on your Proxmox host.
+
+Recommended image:
+
+```text
+ghcr.io/orangespyderman/inkplate10-weather-cal:main
+```
+
+Use the `:next` tag only when you want to test upcoming changes.
+
+If the Proxmox host pulls directly from GHCR without registry credentials, make
+the GitHub package public. Otherwise, configure registry credentials in Proxmox
+before creating the container.
+
+Configure the container with:
+
+- environment variables from `.env.example`
+- port `8080` exposed to your LAN
+- a read-only config mount at `/srv/inkplate/server/config.yaml`
+- persistent storage mounted at `/srv/inkplate/server/data`
+
+The generated PNG is served from:
+
+```text
+http://<container-ip-or-hostname>:8080/calendar.png
+```
+
+Known caveats:
+
+- Proxmox OCI support is newer than standard Docker/Podman workflows.
+- Proxmox mount and environment-variable management is not the same as Compose.
+- Firefox/Geckodriver should be tested on the target Proxmox host.
+- The renderer is tuned for Inkplate 10 portrait output at `825x1200`.


### PR DESCRIPTION
Add a GHCR publish workflow for multi-arch amd64/arm64 images, with separate channel tags for main and next. Add OCI image metadata labels to the Dockerfile and provide a checked-in .env.example for Docker and OCI deployments.

Update the Docker CI trigger paths and document published image usage, including Docker/Podman examples and Proxmox VE 9.1 OCI LXC caveats.