### PR TITLE
Show zero-percent rain labels

### DIFF
--- a/server/views/calendar.py
+++ b/server/views/calendar.py
@@ -237,7 +237,7 @@ class CalendarPage(Page):
                                                 padding: 4,
                                                 callback: function(value, index, values) {{
                                                     var rain = {1}[index];
-                                                    return rain > 0 ? rain + "%" : "";
+                                                    return rain == null ? "" : rain + "%";
                                                 }}
                                             }}
                                         }}],


### PR DESCRIPTION
## Summary
- show `0%` beneath hourly rain bars instead of leaving the label blank
- preserve blank labels for genuinely missing rain values

## Verification
- `python3 -m py_compile server/views/calendar.py`
- `git diff --check`

This is the focused fix for the v2.1.1 point release.