### PR TITLE
Separate producer, web API, and output profiles

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -44,6 +44,13 @@ jobs:
           docker run --rm inkplate10-weather-cal:ci firefox --version
           docker run --rm inkplate10-weather-cal:ci python3 -m py_compile \
             server/server.py \
+            server/web.py \
+            server/web_server.py \
+            server/container_entrypoint.py \
+            server/configuration.py \
+            server/artifacts.py \
+            server/output_profiles.py \
+            server/renderers.py \
             server/mqtt_diagnostics.py \
             server/mqtt_publisher.py \
             server/utils.py \
@@ -51,3 +58,64 @@ jobs:
             server/views/calendar.py
           docker run --rm inkplate10-weather-cal:ci \
             python3 -m unittest discover -s server/tests -v
+
+      - name: Smoke test Gunicorn web service
+        run: |
+          mkdir -p "$RUNNER_TEMP/inkplate-data"
+          cat > "$RUNNER_TEMP/inkplate-config.yaml" <<'EOF'
+          server:
+            enabled: true
+            port: 8080
+          EOF
+          cat > "$RUNNER_TEMP/inkplate-data/weather.json" <<'EOF'
+          {"schema_version":"1.0","generated_at":"2026-06-09T00:00:00+00:00","current":{},"hourly":[]}
+          EOF
+          mkdir -p "$RUNNER_TEMP/inkplate-data/outputs/inkplate10-portrait"
+          printf '\211PNG\r\n\032\n' > "$RUNNER_TEMP/inkplate-data/outputs/inkplate10-portrait/calendar.png"
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["RUNNER_TEMP"]) / "inkplate-data"
+
+          def artifact(path):
+              stat = path.stat()
+              return {
+                  "path": str(path.relative_to(root)),
+                  "signature": {
+                      "mtime_ns": stat.st_mtime_ns,
+                      "size": stat.st_size,
+                  },
+              }
+
+          ready = {
+              "generated_at": "2026-06-09T00:00:00+00:00",
+              "snapshot": artifact(root / "weather.json"),
+              "outputs": {
+                  "inkplate10-portrait": artifact(
+                      root / "outputs/inkplate10-portrait/calendar.png"
+                  )
+              },
+          }
+          (root / "ready.json").write_text(json.dumps(ready), encoding="utf-8")
+          PY
+          docker run --rm -d --name inkplate-web-ci \
+            -p 18080:8080 \
+            -e INKPLATE_CONFIG_FILE=/config.yaml \
+            -v "$RUNNER_TEMP/inkplate-config.yaml:/config.yaml:ro" \
+            -v "$RUNNER_TEMP/inkplate-data:/srv/inkplate/server/data:ro" \
+            inkplate10-weather-cal:ci \
+            python3 server/web_server.py
+          trap 'docker rm -f inkplate-web-ci >/dev/null 2>&1 || true' EXIT
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent http://127.0.0.1:18080/api/v1/ready >/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+          curl --fail http://127.0.0.1:18080/api/v1/health
+          curl --fail http://127.0.0.1:18080/api/v1/ready
+          curl --fail http://127.0.0.1:18080/api/v1/weather
+          curl --fail http://127.0.0.1:18080/outputs/inkplate10-portrait/calendar.png
+          curl --fail http://127.0.0.1:18080/calendar.png

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,4 +62,4 @@ ENV GECKODRIVER_PATH=/usr/local/bin/geckodriver
 
 EXPOSE 8080
 
-CMD ["python3", "server/server.py"]
+CMD ["python3", "server/container_entrypoint.py"]

--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ Both a server and client are required. The main workload is on the server, which
 1. Gets any relevant new data (ie. weather, maps).
 2. Generates a HTML file using a Python HTML translator [Airium](https://pypi.org/project/airium/).
 3. [Selenium](https://pypi.org/project/selenium/) then uses [Geckodriver](https://github.com/mozilla/geckodriver) to make [Firefox](https://www.mozilla.org/firefox/) capture the generated HTML file as a PNG screenshot that fits the dimensions of e-ink resolution.
-4. A [Flask](https://flask.palletsprojects.com/en/2.3.x/) server is then started to serve the generated PNG image to the client.
+4. A separate Gunicorn/Flask web process serves the generated PNG and weather
+   API from the shared artifact directory.
 5. (Optional) The server publishes weather snapshots and listens for Inkplate diagnostics over MQTT.
-6. Depending on configuration the server will either shutdown, run indefinitely, or shutdown after a certain number of times the image is served.
-7. A cronjob ensures the server is refreshed before the client's configured refresh interval elapses.
+6. The producer either refreshes indefinitely or generates one artifact set and
+   exits; web serving has an independent lifecycle.
+7. A cronjob can run the producer before the client's configured refresh interval elapses.
 
 #### Features:
 
@@ -83,7 +85,7 @@ See the [server](/server) for more features.
 
 - **Raspberry Pi Zero W ~€40**
 
-  To run the server, you will need something that can run Python 3 and Firefox/Geckodriver. The server itself is lightweight with the only real work involved being Geckodriver generating a PNG image before serving it to the client. It can also be configured to auto-shutdown when it has successfully served the image to the client. The Docker image currently targets `amd64` and `arm64`, so it is a better fit for a 64-bit Raspberry Pi or similar SBC. A 32-bit Raspberry Pi Zero W may need a native/manual setup rather than the supplied container.
+  To run the server, you will need something that can run Python 3 and Firefox/Geckodriver. The producer does the heavier PNG rendering work while the Gunicorn web process remains available independently. The Docker image currently targets `amd64` and `arm64`, so it is a better fit for a 64-bit Raspberry Pi or similar SBC. A 32-bit Raspberry Pi Zero W may need a native/manual setup rather than the supplied container.
 
 - **Black photo frame 8"x10" ~€10**
 
@@ -145,6 +147,10 @@ The server also exposes versioned data and output endpoints:
 `/calendar.png` remains available as a compatibility alias for existing
 Inkplate firmware.
 
+Named outputs are profile-driven. Additional display sizes and renderer
+implementations can be enabled as separate profiles while `/calendar.png`
+continues to serve the configured default.
+
 ## MQTT
 
 The server can optionally publish the normalized weather snapshot to MQTT for
@@ -159,8 +165,8 @@ and example clients such as the
 ## Server Installation
 
 The recommended server setup is the interactive installer. It can configure
-either Docker Compose from this checkout or a native systemd service under
-`/srv/inkplate` on a Debian/Ubuntu-style host or LXC.
+either Docker Compose from this checkout or native producer and web systemd
+services under `/srv/inkplate` on a Debian/Ubuntu-style host or LXC.
 
 Run it from the repository root:
 
@@ -207,7 +213,7 @@ For troubleshooting:
 
 ```bash
 docker compose logs -f
-sudo journalctl -u inkplate -f
+sudo journalctl -u inkplate-producer -u inkplate -f
 ```
 
 If Docker reports socket permission errors after adding a user to the `docker`

--- a/README.md
+++ b/README.md
@@ -133,6 +133,18 @@ mode so the server keeps refreshing and serving the PNG continuously. The
 browser viewer uses a separate inline image route and does not interfere with
 the Inkplate client's `/calendar.png` download route.
 
+The server also exposes versioned data and output endpoints:
+
+```text
+/api/v1/weather
+/api/v1/health
+/api/v1/ready
+/outputs/inkplate10-portrait/calendar.png
+```
+
+`/calendar.png` remains available as a compatibility alias for existing
+Inkplate firmware.
+
 ## MQTT
 
 The server can optionally publish the normalized weather snapshot to MQTT for

--- a/bin/inkplate-producer.service
+++ b/bin/inkplate-producer.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Inkplate weather calendar web service
+Description=Inkplate weather calendar artifact producer
 After=network-online.target
 Wants=network-online.target
 StartLimitIntervalSec=60
@@ -14,7 +14,7 @@ EnvironmentFile=/etc/inkplate/weather.env
 ExecStartPre=/usr/bin/test -x /srv/inkplate/inkplate_venv/bin/python3
 ExecStartPre=/usr/bin/test -d /srv/inkplate
 ExecStartPre=/usr/bin/test -f /etc/inkplate/weather.env
-ExecStart=/srv/inkplate/inkplate_venv/bin/python3 /srv/inkplate/server/web_server.py
+ExecStart=/srv/inkplate/inkplate_venv/bin/python3 /srv/inkplate/server/server.py
 Restart=on-failure
 RestartSec=5
 TimeoutStopSec=30
@@ -22,7 +22,6 @@ StandardOutput=journal
 StandardError=journal
 UMask=0077
 
-# Security hardening - adjust if your service needs broader access
 NoNewPrivileges=true
 PrivateTmp=true
 PrivateDevices=true
@@ -36,7 +35,6 @@ RestrictSUIDSGID=true
 LockPersonality=true
 SystemCallArchitectures=native
 
-# Resource limits (tweak as needed)
 LimitNOFILE=4096
 LimitNPROC=512
 

--- a/bin/install_server.py
+++ b/bin/install_server.py
@@ -27,6 +27,7 @@ INSTALL_DIR = Path("/srv/inkplate")
 VENV_DIR = INSTALL_DIR / "inkplate_venv"
 NATIVE_ENV_FILE = Path("/etc/inkplate/weather.env")
 SERVICE_FILE = Path("/etc/systemd/system/inkplate.service")
+PRODUCER_SERVICE_FILE = Path("/etc/systemd/system/inkplate-producer.service")
 DOCKER_ENV_FILE = Path(".env")
 SERVER_CONFIG = Path("server/config/config.yaml")
 LEGACY_SERVER_CONFIG = Path("server/config.yaml")
@@ -122,9 +123,11 @@ def configure_answers(path: Path | None, non_interactive: bool) -> None:
 def ensure_repo_root(repo_root: Path) -> None:
     required = [
         repo_root / "server" / "server.py",
+        repo_root / "server" / "web_server.py",
         repo_root / "server" / "requirements.txt",
         repo_root / "docker-compose.yml",
         repo_root / "bin" / "inkplate.service",
+        repo_root / "bin" / "inkplate-producer.service",
     ]
     missing = [str(path) for path in required if not path.exists()]
     if missing:
@@ -177,7 +180,12 @@ def install_docker(repo_root: Path, dry_run: bool) -> None:
 def install_systemd(repo_root: Path, dry_run: bool) -> None:
     existing = [
         path
-        for path in (INSTALL_DIR, NATIVE_ENV_FILE, SERVICE_FILE)
+        for path in (
+            INSTALL_DIR,
+            NATIVE_ENV_FILE,
+            SERVICE_FILE,
+            PRODUCER_SERVICE_FILE,
+        )
         if path.exists()
     ]
     action = choose_existing_action("systemd", existing)
@@ -222,13 +230,41 @@ def install_systemd(repo_root: Path, dry_run: bool) -> None:
             sudo=True,
             dry_run=dry_run,
         )
+        run(
+            [
+                "bin/install_service",
+                "--unit-file",
+                "bin/inkplate-producer.service",
+                "--service-name",
+                "inkplate-producer",
+                "--no-start",
+            ],
+            sudo=True,
+            dry_run=dry_run,
+        )
 
-    if prompt_yes_no("Start or restart the systemd service now?", default=True, key="start_now"):
-        run(["systemctl", "restart", "inkplate"], sudo=True, dry_run=dry_run)
-        run(["systemctl", "status", "inkplate", "--no-pager", "-l"], sudo=True, dry_run=dry_run, check=False)
-        print("Logs: sudo journalctl -u inkplate -f")
+    if prompt_yes_no("Start or restart the systemd services now?", default=True, key="start_now"):
+        run(
+            ["systemctl", "restart", "inkplate-producer", "inkplate"],
+            sudo=True,
+            dry_run=dry_run,
+        )
+        run(
+            [
+                "systemctl",
+                "status",
+                "inkplate-producer",
+                "inkplate",
+                "--no-pager",
+                "-l",
+            ],
+            sudo=True,
+            dry_run=dry_run,
+            check=False,
+        )
+        print("Logs: sudo journalctl -u inkplate-producer -u inkplate -f")
     else:
-        print("Start later with: sudo systemctl start inkplate")
+        print("Start later with: sudo systemctl start inkplate-producer inkplate")
 
 
 def existing_config_path(base_dir: Path) -> Path:
@@ -436,9 +472,15 @@ def render_config(answers: dict[str, object], mode: str) -> str:
         "  apikey: ${GOOGLE_API_KEY}",
         "  staticmaps_mapid: ${GOOGLE_STATICMAPS_MAPID}",
         f"location: {answers['location']}",
-        "image:",
-        f"  width: {DEFAULT_IMAGE_WIDTH}",
-        f"  height: {DEFAULT_IMAGE_HEIGHT}",
+        "outputs:",
+        "  default: inkplate10-portrait",
+        "  profiles:",
+        "    inkplate10-portrait:",
+        "      enabled: true",
+        "      renderer: firefox",
+        f"      width: {DEFAULT_IMAGE_WIDTH}",
+        f"      height: {DEFAULT_IMAGE_HEIGHT}",
+        "      filename: calendar.png",
         "mqtt:",
         "  weather:",
         f"    enabled: {yaml_bool(bool(answers['mqtt_weather_enabled']))}",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
           "CMD",
           "python3",
           "-c",
-          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/calendar.png', timeout=5)",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/api/v1/ready', timeout=5)",
         ]
       interval: 1m
       timeout: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,32 @@
+x-inkplate-service: &inkplate-service
+  init: true
+  image: inkplate10-weather-cal:local
+  build:
+    context: .
+    args:
+      GECKOVERSION: v0.37.0
+  restart: unless-stopped
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
+  environment:
+    WEATHER_API_KEY: ${WEATHER_API_KEY:?set WEATHER_API_KEY in .env or the shell}
+    GOOGLE_API_KEY: ${GOOGLE_API_KEY:?set GOOGLE_API_KEY in .env or the shell}
+    GOOGLE_STATICMAPS_MAPID: ${GOOGLE_STATICMAPS_MAPID:?set GOOGLE_STATICMAPS_MAPID in .env or the shell}
+    NETATMO_CLIENT_ID: ${NETATMO_CLIENT_ID:-}
+    NETATMO_CLIENT_SECRET: ${NETATMO_CLIENT_SECRET:-}
+    NETATMO_REFRESH_TOKEN: ${NETATMO_REFRESH_TOKEN:-}
+    NETATMO_DEVICE_ID: ${NETATMO_DEVICE_ID:-}
+    NETATMO_MODULE_ID: ${NETATMO_MODULE_ID:-}
+  volumes:
+    - ./server/config:/srv/inkplate/server/config:ro
+    - inkplate-data:/srv/inkplate/server/data
+
 services:
   inkplate:
-    init: true
-    build:
-      context: .
-      args:
-        GECKOVERSION: v0.37.0
-    restart: unless-stopped
+    <<: *inkplate-service
+    command: ["python3", "server/web_server.py"]
     ports:
       - "8080:8080"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    environment:
-      WEATHER_API_KEY: ${WEATHER_API_KEY:?set WEATHER_API_KEY in .env or the shell}
-      GOOGLE_API_KEY: ${GOOGLE_API_KEY:?set GOOGLE_API_KEY in .env or the shell}
-      GOOGLE_STATICMAPS_MAPID: ${GOOGLE_STATICMAPS_MAPID:?set GOOGLE_STATICMAPS_MAPID in .env or the shell}
-      NETATMO_CLIENT_ID: ${NETATMO_CLIENT_ID:-}
-      NETATMO_CLIENT_SECRET: ${NETATMO_CLIENT_SECRET:-}
-      NETATMO_REFRESH_TOKEN: ${NETATMO_REFRESH_TOKEN:-}
-      NETATMO_DEVICE_ID: ${NETATMO_DEVICE_ID:-}
-      NETATMO_MODULE_ID: ${NETATMO_MODULE_ID:-}
-    volumes:
-      - ./server/config:/srv/inkplate/server/config:ro
-      - inkplate-data:/srv/inkplate/server/data
     healthcheck:
       test:
         [
@@ -34,6 +39,10 @@ services:
       timeout: 10s
       retries: 3
       start_period: 2m
+
+  producer:
+    <<: *inkplate-service
+    command: ["python3", "server/server.py"]
 
 volumes:
   inkplate-data:

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -186,6 +186,7 @@ Full snapshot:
 
 ```json
 {
+  "schema_version": "1.0",
   "generated_at": "2026-06-04T09:00:00+00:00",
   "source": "openweathermapv3",
   "units": "metric",
@@ -215,6 +216,8 @@ Full snapshot:
 The exact weather fields can vary slightly by provider, but `current`,
 `hourly`, `temperature`, `icon`, and `rain_probability` are the fields intended
 for lightweight display clients.
+
+The same canonical payload is available over HTTP at `/api/v1/weather`.
 
 ### `inkplate/weather-calendar/current`
 

--- a/server/EXAMPLE_config.yaml
+++ b/server/EXAMPLE_config.yaml
@@ -24,12 +24,15 @@ google:
   apikey: ${GOOGLE_API_KEY}
   staticmaps_mapid: ${GOOGLE_STATICMAPS_MAPID}
 location: Landry, FR
-image:
-  # The renderer is tuned for Inkplate 10 portrait output. These values set the
-  # screenshot target, but arbitrary dimensions are not currently guaranteed to
-  # scale the full layout correctly.
-  width: 825
-  height: 1200
+outputs:
+  default: inkplate10-portrait
+  profiles:
+    inkplate10-portrait:
+      enabled: true
+      renderer: firefox
+      width: 825
+      height: 1200
+      filename: calendar.png
 mqtt:
   weather:
     # Optional weather data publisher for other local clients.

--- a/server/EXAMPLE_docker_config.yaml
+++ b/server/EXAMPLE_docker_config.yaml
@@ -24,12 +24,15 @@ google:
   apikey: ${GOOGLE_API_KEY}
   staticmaps_mapid: ${GOOGLE_STATICMAPS_MAPID}
 location: Landry, FR
-image:
-  # The renderer is tuned for Inkplate 10 portrait output. These values set the
-  # screenshot target, but arbitrary dimensions are not currently guaranteed to
-  # scale the full layout correctly.
-  width: 825
-  height: 1200
+outputs:
+  default: inkplate10-portrait
+  profiles:
+    inkplate10-portrait:
+      enabled: true
+      renderer: firefox
+      width: 825
+      height: 1200
+      filename: calendar.png
 mqtt:
   weather:
     # Optional weather data publisher for other local clients.

--- a/server/README.md
+++ b/server/README.md
@@ -15,8 +15,25 @@ Example 1                  | Example 2                 | Example 3
 - Uses [AccuWeather](https://developer.accuweather.com/) or [OpenWeatherMap](https://openweathermap.org/api) APIs for weather data.
 - Uses Google's [StaticMaps API](https://developers.google.com/maps/documentation/maps-static/overview) to generate a static map of your area.
 - Uses [Airium](https://pypi.org/project/airium/) then [Selenium](https://pypi.org/project/selenium/) / [Geckodriver](https://github.com/mozilla/geckodriver) / [Firefox](https://www.mozilla.org/firefox/) to generate HTML and save it as PNG files for image serving.
-- Uses [Flask](https://flask.palletsprojects.com/en/2.3.x/) to serve images and
-  a browser/PWA viewer.
+- Uses [Gunicorn](https://gunicorn.org/) and
+  [Flask](https://flask.palletsprojects.com/en/2.3.x/) to serve images, the
+  weather API, and a browser/PWA viewer independently from artifact generation.
+
+The runtime has two roles:
+
+- `server.py` retrieves weather, renders outputs, publishes MQTT data, and
+  atomically updates the shared artifact directory.
+- `web_server.py` launches Gunicorn, which serves only persisted artifacts and
+  does not load weather providers or Selenium.
+
+Docker Compose runs these roles as separate services sharing the
+`inkplate-data` volume. Native installs use `inkplate-producer.service` and
+`inkplate.service`. The standalone OCI image supervises both processes for
+single-container platforms such as Proxmox.
+
+Gunicorn defaults to one worker with two threads to keep the steady-state
+memory footprint suitable for small systems. `INKPLATE_WEB_WORKERS` and
+`INKPLATE_WEB_THREADS` can raise those values for larger deployments.
 
 ## Setup
 
@@ -74,7 +91,7 @@ Logs:
 
 ```bash
 docker compose logs -f
-sudo journalctl -u inkplate -f
+sudo journalctl -u inkplate-producer -u inkplate -f
 ```
 
 If Docker reports socket permission errors after adding a user to the `docker`
@@ -187,6 +204,33 @@ Generated display artifacts use named output profiles:
 GET /outputs/inkplate10-portrait/calendar.png
 ```
 
+Output profiles are configured independently:
+
+```yaml
+outputs:
+  default: inkplate10-portrait
+  profiles:
+    inkplate10-portrait:
+      enabled: true
+      renderer: firefox
+      width: 825
+      height: 1200
+      filename: calendar.png
+```
+
+Each enabled profile has its own URL, dimensions, renderer, and filename.
+Multiple profiles can be rendered in one producer cycle for different display
+types. The `default` profile backs `/calendar.png` and `/app/calendar.png`.
+Legacy `image.width` and `image.height` settings still configure the default
+Inkplate 10 profile when `outputs.profiles` is absent.
+
+Profiles may also contain an `options` mapping for renderer-specific layout or
+style settings. Unknown options are left to the selected renderer.
+
+Only the `firefox` renderer is implemented currently. The registry allows a
+future `pillow` or device-specific renderer without changing artifact storage,
+readiness, or HTTP routing.
+
 The existing `/calendar.png` and `/app/calendar.png` routes remain compatibility
 aliases for the same image. `/calendar.png` retains its attachment response for
 existing Inkplate firmware.
@@ -198,8 +242,10 @@ GET /api/v1/health
 GET /api/v1/ready
 ```
 
-Health reports whether the web application is running. Readiness returns `200`
-only after both the weather snapshot and Inkplate output image exist.
+Health reports whether the Gunicorn web application is running. Readiness
+returns `200` only when the snapshot and output signatures match the completion
+marker written at the end of a successful producer cycle. During an update or
+after an incomplete first cycle it returns `503`.
 
 Snapshots and rendered outputs use stable paths and are atomically replaced, so
 the data directory does not accumulate historical versions. On startup, the
@@ -238,13 +284,13 @@ Empty runtime values do not satisfy required config placeholders such as
 environment. Optional placeholders such as `${NETATMO_CLIENT_ID:-}` continue to
 expand to an empty string when unset.
 
-### Image dimensions
+### Output dimensions
 
-The `image.width` and `image.height` config values set the browser capture
-target for the generated PNG. The current HTML/CSS layout is tuned for Inkplate
-10 portrait output at `825x1200`; those options are not a general layout scaling
-system. Changing them may produce cropped, stretched, or poorly spaced output
-unless the layout is also retuned.
+Each profile's `width` and `height` values set its capture target. The current
+Firefox HTML/CSS layout is tuned for Inkplate 10 portrait output at `825x1200`;
+dimensions alone are not a general layout scaling system. A different device
+size may require its own renderer or renderer `options` to avoid cropped,
+stretched, or poorly spaced output.
 
 ### Browser and PWA viewer
 
@@ -268,28 +314,29 @@ The viewer refreshes the image every 15 minutes and whenever the browser tab or
 installed app becomes visible. It fetches the image from:
 
 ```text
-http://<server-host>:8080/outputs/inkplate10-portrait/calendar.png
+http://<server-host>:8080/app/calendar.png
 ```
 
-The compatibility routes preserve their previous response behavior:
+The compatibility routes preserve their response behavior:
 
-- `/calendar.png` keeps the existing attachment response and increments the
-  Inkplate serve counter used by one-shot server mode.
+- `/calendar.png` keeps the existing attachment response.
 - `/app/calendar.png` serves the same file inline for browsers and does not
-  increment the Inkplate serve counter. New clients should use the named output
-  route.
+  affect producer lifecycle. It follows the configured default output profile.
+  Other clients should use a named output route when they require a specific
+  profile.
 
-For the browser/PWA viewer, keep the server running continuously:
+For automatic weather refresh, keep the producer running continuously:
 
 ```yaml
 server:
   alwayson: true
 ```
 
-Without `server.alwayson: true`, the server can shut down after the configured
-one-shot lifetime or after the Inkplate has fetched `/calendar.png`. Docker
-Compose and the example Docker config already use `server.alwayson: true`;
-one-shot mode is mainly useful for scheduled Inkplate-only refresh workflows.
+Without `server.alwayson: true`, the producer generates one complete artifact
+set and exits. Gunicorn remains independent and continues serving the last
+successful artifact set. Docker Compose and the example Docker config use
+`server.alwayson: true`; one-shot producer mode is useful for scheduled refresh
+workflows.
 
 To use it like an app, open `/app` on the device and use the browser's install
 or "Add to Home Screen" action. The client is intentionally simple: it caches
@@ -360,9 +407,11 @@ mkdir -p server/config
 mv server/config.yaml server/config/config.yaml
 ```
 
-Run the server manually:
-```
+Run the producer and web service manually in separate terminals:
+
+```bash
 python3 server/server.py
+python3 server/web_server.py
 ```
 
 Run the server 9am each day:
@@ -373,7 +422,9 @@ Add this line:
 ```
 0 9 * * * /usr/bin/python3 /path/to/inkplate10-weather-cal/server/server.py
 ```
-`/path/to/inkplate10-weather-cal` should be updated to the absolute path of your checkout.
+This scheduled form expects `server.alwayson: false`; keep
+`server/web_server.py` running separately. `/path/to/inkplate10-weather-cal`
+should be updated to the absolute path of your checkout.
 
 For a managed native service, prefer `./bin/install_server` unless you need to
 repair individual systemd pieces manually.
@@ -381,8 +432,8 @@ repair individual systemd pieces manually.
 ## Running in Docker
 
 The repository root contains the Dockerfile and `docker-compose.yml`. The image
-installs Firefox, Geckodriver, and the required Python modules, then runs the
-server as an unprivileged `inkplate` user.
+installs Firefox, Geckodriver, Gunicorn, and the required Python modules, then
+runs as an unprivileged `inkplate` user.
 
 ### Configure
 
@@ -392,9 +443,9 @@ Create a Docker server config from the example:
 cp server/config/EXAMPLE_config.yaml server/config/config.yaml
 ```
 
-For Docker, keep `server.alwayson: true`. The compose file uses
-`restart: unless-stopped`; one-shot server mode exits after serving or timing
-out and would otherwise restart repeatedly.
+For Docker Compose, keep `server.alwayson: true`. The producer service uses
+`restart: unless-stopped`, so a successful one-shot producer would otherwise be
+started repeatedly.
 
 Create a local `.env` file in the repository root. Docker Compose reads this
 file and passes the values into the container:
@@ -418,8 +469,9 @@ NETATMO_DEVICE_ID=
 NETATMO_MODULE_ID=
 ```
 
-The compose file mounts `server/config` read-only and stores mutable
-runtime data in the named `inkplate-data` volume. The Docker example sets the
+Compose runs separate `inkplate` web and `producer` services. Both mount
+`server/config` read-only and share mutable runtime data in the named
+`inkplate-data` volume. The Docker example sets the
 Netatmo token file to `data/netatmo-token.json` so refreshed tokens survive
 container replacement. Compose requires explicit values for
 `WEATHER_API_KEY`, `GOOGLE_API_KEY`, and `GOOGLE_STATICMAPS_MAPID`.
@@ -468,8 +520,8 @@ Or detach it:
 docker compose up --build -d
 ```
 
-To use the published image instead of building locally, replace the Compose
-service `build:` block with:
+To use the published image instead of building locally, change the shared
+`image:` value and remove its `build:` block:
 
 ```yaml
 image: ghcr.io/orangespyderman/inkplate10-weather-cal:main

--- a/server/README.md
+++ b/server/README.md
@@ -168,6 +168,44 @@ Publishing failures are logged but do not stop image generation or HTTP
 serving. See [MQTT Weather and Diagnostics](../docs/mqtt.md) for broker setup,
 payload details, topic examples, and example clients.
 
+### HTTP API and outputs
+
+Each successful weather retrieval is persisted and exposed through a versioned
+JSON endpoint:
+
+```text
+GET /api/v1/weather
+```
+
+The response uses the same payload as the base MQTT weather topic and includes
+`schema_version`. It provides `ETag` and `Last-Modified` validators. The
+endpoint returns `503` until a snapshot is available.
+
+Generated display artifacts use named output profiles:
+
+```text
+GET /outputs/inkplate10-portrait/calendar.png
+```
+
+The existing `/calendar.png` and `/app/calendar.png` routes remain compatibility
+aliases for the same image. `/calendar.png` retains its attachment response for
+existing Inkplate firmware.
+
+Operational endpoints are:
+
+```text
+GET /api/v1/health
+GET /api/v1/ready
+```
+
+Health reports whether the web application is running. Readiness returns `200`
+only after both the weather snapshot and Inkplate output image exist.
+
+Snapshots and rendered outputs use stable paths and are atomically replaced, so
+the data directory does not accumulate historical versions. On startup, the
+producer removes temporary artifact files older than 24 hours that may remain
+after an interrupted write. Valid snapshots and outputs are never age-pruned.
+
 The diagnostic listener is independent from weather publishing. It records
 non-retained messages from the Inkplate through the `MQTT` logger and
 resubscribes after reconnecting. The matching firmware topic is configured in
@@ -230,16 +268,16 @@ The viewer refreshes the image every 15 minutes and whenever the browser tab or
 installed app becomes visible. It fetches the image from:
 
 ```text
-http://<server-host>:8080/app/calendar.png
+http://<server-host>:8080/outputs/inkplate10-portrait/calendar.png
 ```
 
-This browser-facing image route is intentionally separate from the Inkplate
-route:
+The compatibility routes preserve their previous response behavior:
 
 - `/calendar.png` keeps the existing attachment response and increments the
   Inkplate serve counter used by one-shot server mode.
 - `/app/calendar.png` serves the same file inline for browsers and does not
-  increment the Inkplate serve counter.
+  increment the Inkplate serve counter. New clients should use the named output
+  route.
 
 For the browser/PWA viewer, keep the server running continuously:
 

--- a/server/artifacts.py
+++ b/server/artifacts.py
@@ -1,0 +1,73 @@
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+
+
+DEFAULT_OUTPUT_PROFILE = "inkplate10-portrait"
+DEFAULT_TEMPORARY_FILE_MAX_AGE_SECONDS = 24 * 60 * 60
+
+
+class ArtifactStore:
+    def __init__(self, root):
+        self.root = Path(root)
+
+    @property
+    def snapshot_path(self):
+        return self.root / "weather.json"
+
+    def output_path(self, profile, filename):
+        return self.root / "outputs" / profile / filename
+
+    def write_snapshot(self, snapshot):
+        self.write_json(self.snapshot_path, snapshot.to_payload())
+
+    def cleanup_stale_temporary_files(
+        self,
+        max_age_seconds=DEFAULT_TEMPORARY_FILE_MAX_AGE_SECONDS,
+        now=None,
+    ):
+        if max_age_seconds < 0:
+            raise ValueError("max_age_seconds must be non-negative")
+        if not self.root.exists():
+            return []
+
+        cutoff = (time.time() if now is None else now) - max_age_seconds
+        removed = []
+        for path in self.root.rglob(".*"):
+            if (
+                path.is_file()
+                and _is_temporary_artifact(path)
+                and path.stat().st_mtime < cutoff
+            ):
+                path.unlink()
+                removed.append(path)
+        return removed
+
+    @staticmethod
+    def write_json(path, value):
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, temporary_path = tempfile.mkstemp(
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as output:
+                json.dump(value, output)
+                output.write("\n")
+                output.flush()
+                os.fsync(output.fileno())
+            os.replace(temporary_path, path)
+        except Exception:
+            try:
+                os.unlink(temporary_path)
+            except FileNotFoundError:
+                pass
+            raise
+
+
+def _is_temporary_artifact(path):
+    return ".tmp" in path.name

--- a/server/artifacts.py
+++ b/server/artifacts.py
@@ -4,8 +4,6 @@ import tempfile
 import time
 from pathlib import Path
 
-
-DEFAULT_OUTPUT_PROFILE = "inkplate10-portrait"
 DEFAULT_TEMPORARY_FILE_MAX_AGE_SECONDS = 24 * 60 * 60
 
 
@@ -17,11 +15,62 @@ class ArtifactStore:
     def snapshot_path(self):
         return self.root / "weather.json"
 
+    @property
+    def ready_path(self):
+        return self.root / "ready.json"
+
     def output_path(self, profile, filename):
         return self.root / "outputs" / profile / filename
 
     def write_snapshot(self, snapshot):
         self.write_json(self.snapshot_path, snapshot.to_payload())
+
+    def write_ready(self, snapshot, profiles):
+        outputs = {}
+        for profile in profiles.values():
+            output_path = self.output_path(profile.name, profile.filename)
+            outputs[profile.name] = {
+                "path": str(output_path.relative_to(self.root)),
+                "signature": self.file_signature(output_path),
+                "renderer": profile.renderer,
+            }
+
+        self.write_json(
+            self.ready_path,
+            {
+                "generated_at": snapshot.generated_at.isoformat(),
+                "snapshot": {
+                    "path": self.snapshot_path.name,
+                    "signature": self.file_signature(self.snapshot_path),
+                },
+                "outputs": outputs,
+            },
+        )
+
+    def output_status(self, profiles):
+        status = {name: False for name in profiles}
+        try:
+            with self.ready_path.open(encoding="utf-8") as ready_file:
+                ready = json.load(ready_file)
+            snapshot = ready["snapshot"]
+            snapshot_matches = (
+                snapshot["signature"]
+                == self.file_signature(self.root / snapshot["path"])
+            )
+            for name, profile in profiles.items():
+                output = ready["outputs"][name]
+                expected_path = self.output_path(name, profile.filename)
+                status[name] = (
+                    snapshot_matches
+                    and self.root / output["path"] == expected_path
+                    and output["signature"] == self.file_signature(expected_path)
+                )
+        except (KeyError, OSError, TypeError, json.JSONDecodeError):
+            pass
+        return status
+
+    def producer_cycle_complete(self, profiles):
+        return all(self.output_status(profiles).values())
 
     def cleanup_stale_temporary_files(
         self,
@@ -67,6 +116,14 @@ class ArtifactStore:
             except FileNotFoundError:
                 pass
             raise
+
+    @staticmethod
+    def file_signature(path):
+        stat = Path(path).stat()
+        return {
+            "mtime_ns": stat.st_mtime_ns,
+            "size": stat.st_size,
+        }
 
 
 def _is_temporary_artifact(path):

--- a/server/config/EXAMPLE_config.yaml
+++ b/server/config/EXAMPLE_config.yaml
@@ -24,12 +24,15 @@ google:
   apikey: ${GOOGLE_API_KEY}
   staticmaps_mapid: ${GOOGLE_STATICMAPS_MAPID}
 location: Landry, FR
-image:
-  # The renderer is tuned for Inkplate 10 portrait output. These values set the
-  # screenshot target, but arbitrary dimensions are not currently guaranteed to
-  # scale the full layout correctly.
-  width: 825
-  height: 1200
+outputs:
+  default: inkplate10-portrait
+  profiles:
+    inkplate10-portrait:
+      enabled: true
+      renderer: firefox
+      width: 825
+      height: 1200
+      filename: calendar.png
 mqtt:
   weather:
     # Optional weather data publisher for other local clients.

--- a/server/configuration.py
+++ b/server/configuration.py
@@ -1,0 +1,45 @@
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+from utils import expand_env_vars
+
+
+SERVER_DIR = Path(__file__).resolve().parent
+DEFAULT_CONFIG_PATH = SERVER_DIR / "config.yaml"
+DEFAULT_CONFIG_DIR_PATH = SERVER_DIR / "config" / "config.yaml"
+
+
+def resolve_config_path():
+    env_config_path = os.environ.get("INKPLATE_CONFIG_FILE")
+    if env_config_path:
+        path = Path(env_config_path)
+        if path.is_file():
+            return path
+
+        print(
+            f"INKPLATE_CONFIG_FILE points to a missing config file: {path}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    if DEFAULT_CONFIG_DIR_PATH.is_file():
+        return DEFAULT_CONFIG_DIR_PATH
+
+    if DEFAULT_CONFIG_PATH.is_file():
+        return DEFAULT_CONFIG_PATH
+
+    print(
+        "No config file found. Checked "
+        f"{DEFAULT_CONFIG_DIR_PATH} and {DEFAULT_CONFIG_PATH}.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+
+def load_config():
+    config_path = resolve_config_path()
+    with config_path.open(encoding="utf-8") as config_file:
+        return config_path, expand_env_vars(yaml.safe_load(config_file))

--- a/server/container_entrypoint.py
+++ b/server/container_entrypoint.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+
+SERVER_DIR = Path(__file__).resolve().parent
+
+
+def terminate(processes):
+    for process in processes:
+        if process.poll() is None:
+            process.terminate()
+    for process in processes:
+        if process.poll() is None:
+            try:
+                process.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+
+
+def main():
+    producer = subprocess.Popen([sys.executable, str(SERVER_DIR / "server.py")])
+    web = subprocess.Popen([sys.executable, str(SERVER_DIR / "web_server.py")])
+    processes = [producer, web]
+
+    def stop(signum, frame):
+        terminate(processes)
+
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+
+    while True:
+        web_status = web.poll()
+        producer_status = producer.poll()
+        if web_status is not None:
+            terminate(processes)
+            return web_status
+        if producer_status is not None:
+            if producer_status != 0:
+                terminate(processes)
+                return producer_status
+            return web.wait()
+        try:
+            producer.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/output_profiles.py
+++ b/server/output_profiles.py
@@ -1,0 +1,133 @@
+from dataclasses import dataclass, field
+import json
+import os
+
+
+DEFAULT_OUTPUT_PROFILE = "inkplate10-portrait"
+DEFAULT_OUTPUT_FILENAME = "calendar.png"
+DEFAULT_RENDERER = "firefox"
+DEFAULT_WIDTH = 825
+DEFAULT_HEIGHT = 1200
+OUTPUT_PROFILES_ENV = "INKPLATE_OUTPUT_PROFILES"
+DEFAULT_OUTPUT_PROFILE_ENV = "INKPLATE_DEFAULT_OUTPUT_PROFILE"
+
+
+@dataclass(frozen=True)
+class OutputProfile:
+    name: str
+    renderer: str
+    width: int
+    height: int
+    filename: str = DEFAULT_OUTPUT_FILENAME
+    options: dict = field(default_factory=dict)
+
+
+def load_output_profiles(config):
+    outputs_config = config.get("outputs") or {}
+    configured_profiles = outputs_config.get("profiles")
+
+    if configured_profiles is None:
+        image_config = config.get("image") or {}
+        profiles = {
+            DEFAULT_OUTPUT_PROFILE: OutputProfile(
+                name=DEFAULT_OUTPUT_PROFILE,
+                renderer=DEFAULT_RENDERER,
+                width=int(image_config.get("width", DEFAULT_WIDTH)),
+                height=int(image_config.get("height", DEFAULT_HEIGHT)),
+            )
+        }
+    else:
+        profiles = {}
+        for name, profile_config in configured_profiles.items():
+            profile_config = profile_config or {}
+            if not profile_config.get("enabled", True):
+                continue
+            profiles[name] = OutputProfile(
+                name=name,
+                renderer=profile_config.get("renderer", DEFAULT_RENDERER),
+                width=int(profile_config.get("width", DEFAULT_WIDTH)),
+                height=int(profile_config.get("height", DEFAULT_HEIGHT)),
+                filename=profile_config.get("filename", DEFAULT_OUTPUT_FILENAME),
+                options=profile_config.get("options") or {},
+            )
+
+    default_profile = outputs_config.get("default", DEFAULT_OUTPUT_PROFILE)
+    validate_output_profiles(profiles, default_profile)
+    return profiles, default_profile
+
+
+def validate_output_profiles(profiles, default_profile):
+    if not profiles:
+        raise ValueError("at least one output profile must be enabled")
+    if default_profile not in profiles:
+        raise ValueError(
+            f"default output profile {default_profile!r} is not enabled"
+        )
+
+    for profile in profiles.values():
+        if (
+            not profile.name
+            or "/" in profile.name
+            or "\\" in profile.name
+            or profile.name in {".", ".."}
+        ):
+            raise ValueError(f"invalid output profile name {profile.name!r}")
+        if profile.width <= 0 or profile.height <= 0:
+            raise ValueError(
+                f"output profile {profile.name!r} dimensions must be positive"
+            )
+        if not profile.renderer:
+            raise ValueError(
+                f"output profile {profile.name!r} renderer is required"
+            )
+        if not isinstance(profile.options, dict):
+            raise ValueError(
+                f"output profile {profile.name!r} options must be a mapping"
+            )
+        if (
+            not profile.filename
+            or "/" in profile.filename
+            or "\\" in profile.filename
+            or profile.filename in {".", ".."}
+        ):
+            raise ValueError(
+                f"invalid output filename {profile.filename!r}"
+            )
+        if not profile.filename.lower().endswith(".png"):
+            raise ValueError(
+                f"output profile {profile.name!r} filename must end in .png"
+            )
+
+
+def export_output_profiles(profiles, default_profile):
+    os.environ[OUTPUT_PROFILES_ENV] = json.dumps(
+        {
+            name: {
+                "renderer": profile.renderer,
+                "width": profile.width,
+                "height": profile.height,
+                "filename": profile.filename,
+                "options": profile.options,
+            }
+            for name, profile in profiles.items()
+        }
+    )
+    os.environ[DEFAULT_OUTPUT_PROFILE_ENV] = default_profile
+
+
+def load_exported_output_profiles():
+    serialized = os.environ.get(OUTPUT_PROFILES_ENV)
+    if not serialized:
+        return load_output_profiles({})
+
+    values = json.loads(serialized)
+    profiles = {
+        name: OutputProfile(name=name, **profile)
+        for name, profile in values.items()
+    }
+    default_profile = os.environ.get(
+        DEFAULT_OUTPUT_PROFILE_ENV,
+        DEFAULT_OUTPUT_PROFILE,
+    )
+    validate_output_profiles(profiles, default_profile)
+    return profiles, default_profile

--- a/server/renderers.py
+++ b/server/renderers.py
@@ -1,0 +1,33 @@
+from views.calendar import CalendarPage
+
+
+class FirefoxCalendarRenderer:
+    name = "firefox"
+
+    def render(
+        self,
+        snapshot,
+        map_url,
+        output_path,
+        width,
+        height,
+        options=None,
+    ):
+        page = CalendarPage(
+            width,
+            height,
+            output_path=output_path,
+        )
+        page.template(
+            map_url=map_url,
+            daily_summary=snapshot.daily_summary,
+            hourly_forecasts=snapshot.hourly_forecasts,
+        )
+        page.save()
+
+
+def build_renderer(name):
+    if name == FirefoxCalendarRenderer.name:
+        return FirefoxCalendarRenderer()
+
+    raise ValueError(f"unsupported output renderer {name!r}")

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -4,6 +4,7 @@ packaging==26.2
 PyYAML==6.0.3
 googlemaps==4.10.0
 Flask==3.1.3
+gunicorn==23.0.0
 Pillow==12.2.0
 protobuf==7.35.0
 requests==2.34.2

--- a/server/server.py
+++ b/server/server.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import io
 import sys
 import yaml
 import time
@@ -12,22 +11,37 @@ import logging.config
 from utils import expand_env_vars, get_prop, get_prop_by_keys
 from mqtt_diagnostics import MqttDiagnosticListener
 from mqtt_publisher import MqttWeatherPublisher
+from artifacts import ArtifactStore, DEFAULT_OUTPUT_PROFILE
 from weather.snapshot import WeatherSnapshot
+from web import create_app
 from views.calendar import CalendarPage
 from google.api import GoogleAPIService
 from werkzeug.serving import make_server
-from flask import Flask, send_file, abort, send_from_directory
 
 cwd = os.path.dirname(os.path.realpath(__file__))
-pwa_dir = os.path.join(cwd, "views", "pwa")
 default_config_path = os.path.join(cwd, "config.yaml")
 default_config_dir_path = os.path.join(cwd, "config", "config.yaml")
 log = None
 
-app = Flask(__name__)
 # number of times served
 server_num_serves = 0
 server_max_serves = 1
+
+
+def record_legacy_calendar_serve():
+    global server_num_serves
+    server_num_serves += 1
+    if log is not None:
+        log.info("Served the image")
+
+
+artifact_store = ArtifactStore(
+    os.environ.get("INKPLATE_DATA_DIR", os.path.join(cwd, "data"))
+)
+app = create_app(
+    data_dir=artifact_store.root,
+    legacy_calendar_served=record_legacy_calendar_serve,
+)
 
 
 def main():
@@ -45,6 +59,12 @@ def main():
     logging.config.fileConfig(log_ini_path)
     log = logging.getLogger("server")
     log.info(f"Loaded config from {config_path}")
+    removed_temporary_files = artifact_store.cleanup_stale_temporary_files()
+    if removed_temporary_files:
+        log.info(
+            "Removed %s stale temporary artifact files",
+            len(removed_temporary_files),
+        )
 
     google_apikey = get_prop_by_keys(config, "google", "apikey", required=True)
     weather_service_type = get_prop_by_keys(config, "weather", "service", required=True)
@@ -149,6 +169,7 @@ def main():
                     weather_service_type,
                     weather_metric,
                 )
+                artifact_store.write_snapshot(snapshot)
                 publish_weather_snapshot(weather_publisher, snapshot)
             except Exception as e:
                 error_string = repr(e)
@@ -161,7 +182,9 @@ def main():
             try:
                 # generate page images
                 log.info(f"Generating page")
-                render_calendar_snapshot(snapshot, image_width, image_height, map_url)
+                render_calendar_snapshot(
+                    snapshot, image_width, image_height, map_url, artifact_store
+                )
             except Exception as e:
                 error_string = repr(e)
                 log.error(f"An error occurred whilst creating page!")
@@ -186,6 +209,7 @@ def main():
                 weather_service_type,
                 weather_metric,
             )
+            artifact_store.write_snapshot(snapshot)
             publish_weather_snapshot(weather_publisher, snapshot)
         except Exception as e:
             error_string = repr(e)
@@ -195,7 +219,9 @@ def main():
             log.error(f"Will retry on next cycle...")
         try:
             # generate page images
-            render_calendar_snapshot(snapshot, image_width, image_height, map_url)
+            render_calendar_snapshot(
+                snapshot, image_width, image_height, map_url, artifact_store
+            )
         except Exception as e:
             error_string = repr(e)
             log.error(f"An error occurred whilst creating page!")
@@ -345,8 +371,17 @@ def build_weather_snapshot(
     )
 
 
-def render_calendar_snapshot(snapshot, image_width, image_height, map_url):
-    page = CalendarPage(image_width, image_height)
+def render_calendar_snapshot(
+    snapshot, image_width, image_height, map_url, store=artifact_store
+):
+    page = CalendarPage(
+        image_width,
+        image_height,
+        output_path=store.output_path(
+            DEFAULT_OUTPUT_PROFILE,
+            "calendar.png",
+        ),
+    )
     page.template(
         map_url=map_url,
         daily_summary=snapshot.daily_summary,
@@ -411,114 +446,6 @@ class ServerThread(threading.Thread):
         log.info(f"Stopping http server in {timeout} seconds")
         time.sleep(timeout)
         self.server.shutdown()
-
-
-@app.route("/calendar.png")
-def serve_cal_png():
-    global server_num_serves, server_max_serves
-    """
-    Returns the calendar image directly through send_file
-    """
-
-    path = os.path.join(cwd, "views/calendar.png")
-
-    if not os.path.exists(path):
-        log.error(f"{path}: no such file exists")
-        abort(404)
-
-    f = open(path, "rb")
-    stream = io.BytesIO(f.read())
-    f.close()
-    server_num_serves += 1
-    log.info(f"Served the image")
-
-    return send_file(
-        stream,
-        mimetype="image/png",
-        as_attachment=True,
-        download_name=os.path.basename(path),
-    )
-
-
-@app.route("/")
-@app.route("/app")
-@app.route("/app/")
-@app.route("/app/index.html")
-def serve_pwa():
-    return send_from_directory(pwa_dir, "index.html")
-
-
-@app.route("/app.css")
-def serve_pwa_css():
-    return send_from_directory(pwa_dir, "app.css")
-
-
-@app.route("/app.js")
-def serve_pwa_js():
-    return send_from_directory(pwa_dir, "app.js")
-
-
-@app.route("/manifest.webmanifest")
-def serve_pwa_manifest():
-    return send_from_directory(
-        pwa_dir,
-        "manifest.webmanifest",
-        mimetype="application/manifest+json",
-    )
-
-
-@app.route("/sw.js")
-def serve_pwa_service_worker():
-    return send_from_directory(
-        pwa_dir,
-        "sw.js",
-        mimetype="application/javascript",
-    )
-
-
-@app.route("/icons/<path:filename>")
-def serve_pwa_icon(filename):
-    return send_from_directory(os.path.join(pwa_dir, "icons"), filename)
-
-
-@app.route("/favicon.ico")
-def serve_favicon():
-    return send_from_directory(
-        os.path.join(pwa_dir, "icons"),
-        "weathercal-favicon.ico",
-        mimetype="image/x-icon",
-    )
-
-
-@app.route("/apple-touch-icon.png")
-@app.route("/apple-touch-icon-precomposed.png")
-def serve_apple_touch_icon():
-    return send_from_directory(
-        os.path.join(pwa_dir, "icons"),
-        "weathercal-icon-192.png",
-        mimetype="image/png",
-    )
-
-
-@app.route("/app/calendar.png")
-def serve_pwa_cal_png():
-    """
-    Returns the calendar image for browsers without affecting the Inkplate
-    download route's serve counter or Content-Disposition behavior.
-    """
-
-    path = os.path.join(cwd, "views/calendar.png")
-
-    if not os.path.exists(path):
-        log.error(f"{path}: no such file exists")
-        abort(404)
-
-    return send_file(
-        path,
-        mimetype="image/png",
-        as_attachment=False,
-        max_age=0,
-    )
 
 
 if __name__ == "__main__":

--- a/server/server.py
+++ b/server/server.py
@@ -3,53 +3,30 @@
 
 import os
 import sys
-import yaml
 import time
-import threading
-import datetime as dt
 import logging.config
-from utils import expand_env_vars, get_prop, get_prop_by_keys
+from utils import get_prop, get_prop_by_keys
 from mqtt_diagnostics import MqttDiagnosticListener
 from mqtt_publisher import MqttWeatherPublisher
-from artifacts import ArtifactStore, DEFAULT_OUTPUT_PROFILE
+from artifacts import ArtifactStore
+from configuration import load_config
+from output_profiles import load_output_profiles
+from renderers import build_renderer
 from weather.snapshot import WeatherSnapshot
-from web import create_app
-from views.calendar import CalendarPage
 from google.api import GoogleAPIService
-from werkzeug.serving import make_server
 
 cwd = os.path.dirname(os.path.realpath(__file__))
-default_config_path = os.path.join(cwd, "config.yaml")
-default_config_dir_path = os.path.join(cwd, "config", "config.yaml")
 log = None
-
-# number of times served
-server_num_serves = 0
-server_max_serves = 1
-
-
-def record_legacy_calendar_serve():
-    global server_num_serves
-    server_num_serves += 1
-    if log is not None:
-        log.info("Served the image")
-
 
 artifact_store = ArtifactStore(
     os.environ.get("INKPLATE_DATA_DIR", os.path.join(cwd, "data"))
 )
-app = create_app(
-    data_dir=artifact_store.root,
-    legacy_calendar_served=record_legacy_calendar_serve,
-)
 
 
 def main():
-    global log, server_max_serves
+    global log
 
-    config_path = resolve_config_path()
-    with open(config_path) as config_file:
-        config = expand_env_vars(yaml.safe_load(config_file))
+    config_path, config = load_config()
 
     debug = get_prop(config, "debug", default=False)
     # Create and configure logger
@@ -94,13 +71,17 @@ def main():
     location = get_prop(config, "location", required=True).strip().replace(" ", "")
 
     server_enabled = get_prop_by_keys(config, "server", "enabled", default=True)
-    server_port = get_prop_by_keys(config, "server", "port", default=8080)
     server_always_on = get_prop_by_keys(config, "server", "alwayson", default=False)
     server_refresh_seconds = 3600 * get_prop_by_keys(
         config, "server", "refreshhours", default=3
     )
-    image_width = get_prop_by_keys(config, "image", "width", default=825)
-    image_height = get_prop_by_keys(config, "image", "height", default=1200)
+    output_profiles, default_output_profile = load_output_profiles(config)
+    output_renderers = build_output_renderers(output_profiles)
+    log.info(
+        "Enabled output profiles: %s (default: %s)",
+        ", ".join(output_profiles),
+        default_output_profile,
+    )
 
     mqtt_config = get_prop(config, "mqtt", default={}, required=False) or {}
     weather_publisher = build_mqtt_weather_publisher(
@@ -155,135 +136,40 @@ def main():
     if diagnostic_listener is not None and not diagnostic_listener.start():
         diagnostic_listener = None
 
-    # setup http server
     if server_always_on:
-        http_server = ServerThread(app, server_port)
-        http_server.start()
-        log.info(f"Started always on server")
         while True:
-            log.info(f"Retrieving forecast data")
-            try:
-                snapshot = build_weather_snapshot(
-                    weather_svc,
-                    current_temperature_svc,
-                    weather_service_type,
-                    weather_metric,
-                )
-                artifact_store.write_snapshot(snapshot)
-                publish_weather_snapshot(weather_publisher, snapshot)
-            except Exception as e:
-                error_string = repr(e)
-                log.error(f"An error occurred whilst getting weather data!")
-                log.error(f"The error was :")
-                log.error(f"{error_string}")
-                log.error(f"Sleeping for 120 seconds before retrying....")
-                time.sleep(120)
-                continue
-            try:
-                # generate page images
-                log.info(f"Generating page")
-                render_calendar_snapshot(
-                    snapshot, image_width, image_height, map_url, artifact_store
-                )
-            except Exception as e:
-                error_string = repr(e)
-                log.error(f"An error occurred whilst creating page!")
-                log.error(f"The error was :")
-                log.error(f"{error_string}")
-                log.error(f"Sleeping for 120 seconds before retrying....")
-                time.sleep(120)
-                continue
-            log.info(f"Serving current image for {server_refresh_seconds} seconds")
-            time.sleep(server_refresh_seconds)
-            log.info(f"Woken after {server_refresh_seconds} seconds to refresh image")
-
-    else:
-        server_alive_seconds = get_prop_by_keys(
-            config, "server", "aliveSeconds", default=60
-        )
-        server_max_serves = get_prop_by_keys(config, "server", "maxServes", default=1)
-        try:
-            snapshot = build_weather_snapshot(
+            if not produce_artifacts(
                 weather_svc,
                 current_temperature_svc,
                 weather_service_type,
                 weather_metric,
-            )
-            artifact_store.write_snapshot(snapshot)
-            publish_weather_snapshot(weather_publisher, snapshot)
-        except Exception as e:
-            error_string = repr(e)
-            log.error(f"An error occurred whilst getting weather data!")
-            log.error(f"The error was :")
-            log.error(f"{error_string}")
-            log.error(f"Will retry on next cycle...")
-        try:
-            # generate page images
-            render_calendar_snapshot(
-                snapshot, image_width, image_height, map_url, artifact_store
-            )
-        except Exception as e:
-            error_string = repr(e)
-            log.error(f"An error occurred whilst creating page!")
-            log.error(f"The error was :")
-            log.error(f"{error_string}")
-            log.error(f"Retrying on next cycle")
-        http_server = ServerThread(app, server_port)
-        http_server.start()
+                weather_publisher,
+                map_url,
+                output_profiles,
+                output_renderers,
+                artifact_store,
+            ):
+                log.error("Sleeping for 120 seconds before retrying....")
+                time.sleep(120)
+                continue
+            log.info(f"Sleeping for {server_refresh_seconds} seconds before refresh")
+            time.sleep(server_refresh_seconds)
 
-        enable_wait = server_alive_seconds > 0
-        enable_max_serves = server_max_serves > 0
-
-        if enable_wait:
-            log.info(
-                f"Serving images for {server_alive_seconds} seconds before shutdown"
-            )
-        if enable_max_serves:
-            log.info(
-                f"Serving images for max {server_max_serves} times before shutdown"
-            )
-
-        start_wait_dt = dt.datetime.now()
-        diff = dt.datetime.now() - start_wait_dt
-        while (enable_max_serves and server_num_serves < server_max_serves) and (
-            enable_wait and diff.seconds < server_alive_seconds
-        ):
-            time.sleep(1)
-            diff = dt.datetime.now() - start_wait_dt
-
-        http_server.shutdown(timeout=10)
-
+    else:
+        success = produce_artifacts(
+            weather_svc,
+            current_temperature_svc,
+            weather_service_type,
+            weather_metric,
+            weather_publisher,
+            map_url,
+            output_profiles,
+            output_renderers,
+            artifact_store,
+        )
         if diagnostic_listener is not None:
             diagnostic_listener.stop()
-
-        log.info(f"Exiting")
-        sys.exit(0)
-
-
-def resolve_config_path():
-    env_config_path = os.environ.get("INKPLATE_CONFIG_FILE")
-    if env_config_path:
-        if os.path.isfile(env_config_path):
-            return env_config_path
-
-        print(
-            f"INKPLATE_CONFIG_FILE points to a missing config file: {env_config_path}",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    if os.path.isfile(default_config_dir_path):
-        return default_config_dir_path
-
-    if os.path.isfile(default_config_path):
-        return default_config_path
-
-    print(
-        "No config file found. Checked "
-        f"{default_config_dir_path} and {default_config_path}.",
-        file=sys.stderr,
-    )
-    sys.exit(1)
+        sys.exit(0 if success else 1)
 
 
 def build_current_temperature_service(config, metric):
@@ -371,23 +257,72 @@ def build_weather_snapshot(
     )
 
 
-def render_calendar_snapshot(
-    snapshot, image_width, image_height, map_url, store=artifact_store
+def build_output_renderers(profiles):
+    return {
+        name: build_renderer(profile.renderer)
+        for name, profile in profiles.items()
+    }
+
+
+def render_outputs(
+    snapshot,
+    map_url,
+    profiles,
+    renderers,
+    store=artifact_store,
 ):
-    page = CalendarPage(
-        image_width,
-        image_height,
-        output_path=store.output_path(
-            DEFAULT_OUTPUT_PROFILE,
-            "calendar.png",
-        ),
-    )
-    page.template(
-        map_url=map_url,
-        daily_summary=snapshot.daily_summary,
-        hourly_forecasts=snapshot.hourly_forecasts,
-    )
-    page.save()
+    for name, profile in profiles.items():
+        renderer = renderers[name]
+        renderer.render(
+            snapshot,
+            map_url,
+            store.output_path(profile.name, profile.filename),
+            profile.width,
+            profile.height,
+            profile.options,
+        )
+
+
+def produce_artifacts(
+    weather_svc,
+    current_temperature_svc,
+    weather_service_type,
+    weather_metric,
+    weather_publisher,
+    map_url,
+    profiles,
+    renderers,
+    store=artifact_store,
+):
+    log.info("Retrieving forecast data")
+    try:
+        snapshot = build_weather_snapshot(
+            weather_svc,
+            current_temperature_svc,
+            weather_service_type,
+            weather_metric,
+        )
+    except Exception as exc:
+        log.exception("An error occurred whilst getting weather data: %s", exc)
+        return False
+
+    try:
+        log.info("Generating output profiles")
+        render_outputs(
+            snapshot,
+            map_url,
+            profiles,
+            renderers,
+            store,
+        )
+        store.write_snapshot(snapshot)
+        store.write_ready(snapshot, profiles)
+    except Exception as exc:
+        log.exception("An error occurred whilst creating artifacts: %s", exc)
+        return False
+
+    publish_weather_snapshot(weather_publisher, snapshot)
+    return True
 
 
 def build_mqtt_weather_publisher(mqtt_config):
@@ -428,24 +363,6 @@ def publish_weather_snapshot(weather_publisher, snapshot):
         return
 
     weather_publisher.publish_snapshot(snapshot)
-
-
-class ServerThread(threading.Thread):
-    def __init__(self, app, port, max_serves=1):
-        threading.Thread.__init__(self)
-        self.server = make_server("0.0.0.0", port, app)
-        self.ctx = app.app_context()
-        self.ctx.push()
-        self.max_serves = max_serves
-
-    def run(self):
-        log.info("Starting http server")
-        self.server.serve_forever()
-
-    def shutdown(self, timeout=60):
-        log.info(f"Stopping http server in {timeout} seconds")
-        time.sleep(timeout)
-        self.server.shutdown()
 
 
 if __name__ == "__main__":

--- a/server/tests/test_artifacts.py
+++ b/server/tests/test_artifacts.py
@@ -10,7 +10,8 @@ from unittest import mock
 SERVER_DIR = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SERVER_DIR))
 
-from artifacts import ArtifactStore, DEFAULT_OUTPUT_PROFILE
+from artifacts import ArtifactStore
+from output_profiles import DEFAULT_OUTPUT_PROFILE, OutputProfile
 
 
 class ArtifactStoreTests(unittest.TestCase):
@@ -18,9 +19,28 @@ class ArtifactStoreTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary_dir:
             store = ArtifactStore(temporary_dir)
             snapshot = mock.Mock()
+            snapshot.generated_at = mock.Mock()
+            snapshot.generated_at.isoformat.return_value = (
+                "2026-06-09T00:00:00+00:00"
+            )
             snapshot.to_payload.return_value = {"schema_version": "1.0"}
 
             store.write_snapshot(snapshot)
+            output_path = store.output_path(
+                DEFAULT_OUTPUT_PROFILE,
+                "calendar.png",
+            )
+            output_path.parent.mkdir(parents=True)
+            output_path.write_bytes(b"png")
+            profiles = {
+                DEFAULT_OUTPUT_PROFILE: OutputProfile(
+                    DEFAULT_OUTPUT_PROFILE,
+                    "firefox",
+                    825,
+                    1200,
+                )
+            }
+            store.write_ready(snapshot, profiles)
 
             self.assertEqual(
                 json.loads(store.snapshot_path.read_text(encoding="utf-8")),
@@ -33,6 +53,20 @@ class ArtifactStoreTests(unittest.TestCase):
                 / "inkplate10-portrait"
                 / "calendar.png",
             )
+            ready = json.loads(store.ready_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                ready["snapshot"]["path"],
+                "weather.json",
+            )
+            self.assertEqual(
+                ready["outputs"][DEFAULT_OUTPUT_PROFILE]["path"],
+                "outputs/inkplate10-portrait/calendar.png",
+            )
+            self.assertTrue(store.producer_cycle_complete(profiles))
+
+            output_path.write_bytes(b"new output")
+
+            self.assertFalse(store.producer_cycle_complete(profiles))
 
     def test_removes_only_stale_temporary_artifacts(self):
         with tempfile.TemporaryDirectory() as temporary_dir:

--- a/server/tests/test_artifacts.py
+++ b/server/tests/test_artifacts.py
@@ -1,0 +1,69 @@
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+SERVER_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SERVER_DIR))
+
+from artifacts import ArtifactStore, DEFAULT_OUTPUT_PROFILE
+
+
+class ArtifactStoreTests(unittest.TestCase):
+    def test_writes_snapshot_and_output_paths_under_root(self):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            store = ArtifactStore(temporary_dir)
+            snapshot = mock.Mock()
+            snapshot.to_payload.return_value = {"schema_version": "1.0"}
+
+            store.write_snapshot(snapshot)
+
+            self.assertEqual(
+                json.loads(store.snapshot_path.read_text(encoding="utf-8")),
+                {"schema_version": "1.0"},
+            )
+            self.assertEqual(
+                store.output_path(DEFAULT_OUTPUT_PROFILE, "calendar.png"),
+                pathlib.Path(temporary_dir)
+                / "outputs"
+                / "inkplate10-portrait"
+                / "calendar.png",
+            )
+
+    def test_removes_only_stale_temporary_artifacts(self):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            store = ArtifactStore(temporary_dir)
+            stale = store.root / ".weather.json.old.tmp"
+            current = store.root / ".weather.json.current.tmp"
+            output = store.output_path(DEFAULT_OUTPUT_PROFILE, "calendar.png")
+            output.parent.mkdir(parents=True)
+            stale.write_text("stale", encoding="utf-8")
+            current.write_text("current", encoding="utf-8")
+            output.write_bytes(b"png")
+            os.utime(stale, (100, 100))
+            os.utime(current, (190, 190))
+
+            removed = store.cleanup_stale_temporary_files(
+                max_age_seconds=50,
+                now=200,
+            )
+
+            self.assertEqual(removed, [stale])
+            self.assertFalse(stale.exists())
+            self.assertTrue(current.exists())
+            self.assertTrue(output.exists())
+
+    def test_rejects_negative_temporary_file_max_age(self):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            store = ArtifactStore(temporary_dir)
+
+            with self.assertRaises(ValueError):
+                store.cleanup_stale_temporary_files(max_age_seconds=-1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/tests/test_mqtt.py
+++ b/server/tests/test_mqtt.py
@@ -110,6 +110,7 @@ class MqttWeatherPublisherTests(unittest.TestCase):
         client.publish.return_value = result
         snapshot = mock.Mock()
         snapshot.to_payload.return_value = {
+            "schema_version": "1.0",
             "generated_at": "2026-06-05T00:00:00+00:00",
             "source": "test",
             "units": "metric",

--- a/server/tests/test_output_profiles.py
+++ b/server/tests/test_output_profiles.py
@@ -1,0 +1,71 @@
+import pathlib
+import sys
+import unittest
+
+
+SERVER_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SERVER_DIR))
+
+from output_profiles import DEFAULT_OUTPUT_PROFILE, load_output_profiles
+
+
+class OutputProfileTests(unittest.TestCase):
+    def test_uses_legacy_image_dimensions_when_outputs_are_not_configured(self):
+        profiles, default_profile = load_output_profiles(
+            {"image": {"width": 600, "height": 448}}
+        )
+
+        self.assertEqual(default_profile, DEFAULT_OUTPUT_PROFILE)
+        self.assertEqual(profiles[default_profile].width, 600)
+        self.assertEqual(profiles[default_profile].height, 448)
+        self.assertEqual(profiles[default_profile].renderer, "firefox")
+
+    def test_loads_multiple_enabled_renderer_profiles(self):
+        profiles, default_profile = load_output_profiles(
+            {
+                "outputs": {
+                    "default": "inkplate10-portrait",
+                    "profiles": {
+                        "inkplate10-portrait": {
+                            "renderer": "firefox",
+                            "width": 825,
+                            "height": 1200,
+                        },
+                        "inkplate6-landscape": {
+                            "renderer": "pillow",
+                            "width": 800,
+                            "height": 600,
+                            "filename": "weather.png",
+                            "options": {"layout": "compact"},
+                        },
+                        "disabled": {"enabled": False},
+                    },
+                }
+            }
+        )
+
+        self.assertEqual(default_profile, "inkplate10-portrait")
+        self.assertEqual(
+            list(profiles),
+            ["inkplate10-portrait", "inkplate6-landscape"],
+        )
+        self.assertEqual(profiles["inkplate6-landscape"].renderer, "pillow")
+        self.assertEqual(profiles["inkplate6-landscape"].filename, "weather.png")
+        self.assertEqual(
+            profiles["inkplate6-landscape"].options,
+            {"layout": "compact"},
+        )
+
+    def test_rejects_disabled_default_profile(self):
+        with self.assertRaisesRegex(ValueError, "is not enabled"):
+            load_output_profiles(
+                {
+                    "outputs": {
+                        "default": "disabled",
+                        "profiles": {
+                            "disabled": {"enabled": False},
+                            "enabled": {},
+                        },
+                    }
+                }
+            )

--- a/server/tests/test_server.py
+++ b/server/tests/test_server.py
@@ -1,0 +1,184 @@
+import datetime as dt
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+SERVER_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SERVER_DIR))
+
+import server
+from artifacts import ArtifactStore
+from output_profiles import OutputProfile
+from weather.snapshot import WeatherSnapshot
+
+
+class ProducerTests(unittest.TestCase):
+    def setUp(self):
+        self.log = mock.patch.object(server, "log", mock.Mock())
+        self.log.start()
+
+    def tearDown(self):
+        self.log.stop()
+
+    def test_rejects_unregistered_renderer_before_production(self):
+        profiles = {
+            "future": OutputProfile(
+                "future",
+                "pillow",
+                800,
+                600,
+            )
+        }
+
+        with self.assertRaisesRegex(ValueError, "unsupported output renderer"):
+            server.build_output_renderers(profiles)
+
+    def test_renders_each_profile_with_dimensions_and_options(self):
+        portrait_renderer = mock.Mock()
+        landscape_renderer = mock.Mock()
+        snapshot = mock.Mock()
+        profiles = {
+            "portrait": OutputProfile(
+                "portrait",
+                "firefox",
+                825,
+                1200,
+                options={"layout": "classic"},
+            ),
+            "landscape": OutputProfile(
+                "landscape",
+                "pillow",
+                800,
+                600,
+                filename="weather.png",
+                options={"layout": "compact"},
+            ),
+        }
+        renderers = {
+            "portrait": portrait_renderer,
+            "landscape": landscape_renderer,
+        }
+
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            store = ArtifactStore(temporary_dir)
+            server.render_outputs(
+                snapshot,
+                "map.png",
+                profiles,
+                renderers,
+                store,
+            )
+
+        portrait_renderer.render.assert_called_once_with(
+            snapshot,
+            "map.png",
+            mock.ANY,
+            825,
+            1200,
+            {"layout": "classic"},
+        )
+        landscape_renderer.render.assert_called_once_with(
+            snapshot,
+            "map.png",
+            mock.ANY,
+            800,
+            600,
+            {"layout": "compact"},
+        )
+
+    @mock.patch("server.render_outputs")
+    @mock.patch("server.publish_weather_snapshot")
+    @mock.patch("server.build_weather_snapshot")
+    def test_completed_cycle_publishes_artifacts_and_readiness_last(
+        self,
+        build_snapshot,
+        publish_snapshot,
+        render_outputs,
+    ):
+        snapshot = WeatherSnapshot(
+            daily_summary={},
+            hourly_forecasts=[],
+            weather_source="test",
+            generated_at=dt.datetime(2026, 6, 9, tzinfo=dt.timezone.utc),
+        )
+        build_snapshot.return_value = snapshot
+
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            store = ArtifactStore(temporary_dir)
+            profiles = {
+                "inkplate10-portrait": OutputProfile(
+                    "inkplate10-portrait",
+                    "firefox",
+                    825,
+                    1200,
+                )
+            }
+            renderers = {"inkplate10-portrait": mock.Mock()}
+            output = store.output_path("inkplate10-portrait", "calendar.png")
+
+            def render(*args):
+                output.parent.mkdir(parents=True)
+                output.write_bytes(b"png")
+
+            render_outputs.side_effect = render
+
+            success = server.produce_artifacts(
+                mock.Mock(),
+                None,
+                "test",
+                True,
+                mock.Mock(),
+                "map.png",
+                profiles,
+                renderers,
+                store,
+            )
+
+            self.assertTrue(success)
+            self.assertTrue(store.snapshot_path.is_file())
+            self.assertTrue(store.ready_path.is_file())
+            self.assertTrue(store.producer_cycle_complete(profiles))
+            publish_snapshot.assert_called_once()
+
+    @mock.patch("server.render_outputs", side_effect=RuntimeError("render"))
+    @mock.patch("server.publish_weather_snapshot")
+    @mock.patch("server.build_weather_snapshot")
+    def test_failed_render_does_not_publish_snapshot_or_readiness(
+        self,
+        build_snapshot,
+        publish_snapshot,
+        render_outputs,
+    ):
+        build_snapshot.return_value = WeatherSnapshot({}, [], "test")
+
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            store = ArtifactStore(temporary_dir)
+            profiles = {
+                "inkplate10-portrait": OutputProfile(
+                    "inkplate10-portrait",
+                    "firefox",
+                    825,
+                    1200,
+                )
+            }
+            renderers = {"inkplate10-portrait": mock.Mock()}
+
+            success = server.produce_artifacts(
+                mock.Mock(),
+                None,
+                "test",
+                True,
+                mock.Mock(),
+                "map.png",
+                profiles,
+                renderers,
+                store,
+            )
+
+            self.assertFalse(success)
+            self.assertFalse(store.snapshot_path.exists())
+            self.assertFalse(store.ready_path.exists())
+            publish_snapshot.assert_not_called()

--- a/server/tests/test_snapshot.py
+++ b/server/tests/test_snapshot.py
@@ -1,0 +1,26 @@
+import datetime as dt
+import pathlib
+import sys
+import unittest
+
+
+SERVER_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SERVER_DIR))
+
+from weather.snapshot import WeatherSnapshot
+
+
+class WeatherSnapshotTests(unittest.TestCase):
+    def test_payload_has_versioned_contract(self):
+        snapshot = WeatherSnapshot(
+            daily_summary={},
+            hourly_forecasts=[],
+            weather_source="test",
+            generated_at=dt.datetime(2026, 6, 8, tzinfo=dt.timezone.utc),
+        )
+
+        self.assertEqual(snapshot.to_payload()["schema_version"], "1.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/tests/test_web.py
+++ b/server/tests/test_web.py
@@ -9,7 +9,8 @@ from unittest import mock
 SERVER_DIR = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SERVER_DIR))
 
-from artifacts import ArtifactStore, DEFAULT_OUTPUT_PROFILE
+from artifacts import ArtifactStore
+from output_profiles import DEFAULT_OUTPUT_PROFILE, OutputProfile
 from web import create_app
 
 
@@ -17,10 +18,27 @@ class WebAppTests(unittest.TestCase):
     def setUp(self):
         self.temporary_dir = tempfile.TemporaryDirectory()
         self.store = ArtifactStore(self.temporary_dir.name)
+        self.profiles = {
+            DEFAULT_OUTPUT_PROFILE: OutputProfile(
+                DEFAULT_OUTPUT_PROFILE,
+                "firefox",
+                825,
+                1200,
+            ),
+            "inkplate6-landscape": OutputProfile(
+                "inkplate6-landscape",
+                "pillow",
+                800,
+                600,
+                filename="weather.png",
+            ),
+        }
         self.legacy_calendar_served = mock.Mock()
         self.app = create_app(
             data_dir=self.temporary_dir.name,
             legacy_calendar_served=self.legacy_calendar_served,
+            output_profiles=self.profiles,
+            default_output_profile=DEFAULT_OUTPUT_PROFILE,
         )
         self.app.config["TESTING"] = True
         self.client = self.app.test_client()
@@ -45,7 +63,11 @@ class WebAppTests(unittest.TestCase):
             {
                 "status": "not_ready",
                 "snapshot": False,
-                "outputs": {DEFAULT_OUTPUT_PROFILE: False},
+                "outputs": {
+                    DEFAULT_OUTPUT_PROFILE: False,
+                    "inkplate6-landscape": False,
+                },
+                "producer_cycle_complete": False,
             },
         )
 
@@ -70,6 +92,31 @@ class WebAppTests(unittest.TestCase):
         self.assertIn("Last-Modified", response.headers)
         self.assertEqual(conditional.status_code, 304)
 
+    def test_weather_validator_matches_the_open_file_during_replacement(self):
+        old_payload = {"schema_version": "1.0", "value": "old"}
+        new_payload = {"schema_version": "1.0", "value": "new-and-larger"}
+        ArtifactStore.write_json(self.store.snapshot_path, old_payload)
+        old_size = self.store.snapshot_path.stat().st_size
+        original_json_load = json.load
+
+        def replace_after_read(snapshot_file):
+            payload = original_json_load(snapshot_file)
+            ArtifactStore.write_json(self.store.snapshot_path, new_payload)
+            return payload
+
+        with mock.patch("web.json.load", side_effect=replace_after_read):
+            first = self.client.get("/api/v1/weather")
+
+        second = self.client.get(
+            "/api/v1/weather",
+            headers={"If-None-Match": first.headers["ETag"]},
+        )
+
+        self.assertEqual(first.get_json(), old_payload)
+        self.assertIn(f"-{old_size}", first.headers["ETag"])
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(second.get_json(), new_payload)
+
     def test_serves_named_output_and_legacy_alias(self):
         output_path = self.store.output_path(
             DEFAULT_OUTPUT_PROFILE,
@@ -92,6 +139,52 @@ class WebAppTests(unittest.TestCase):
         output.close()
         legacy.close()
 
+    def test_serves_each_configured_profile_and_rejects_unknown_outputs(self):
+        output_path = self.store.output_path(
+            "inkplate6-landscape",
+            "weather.png",
+        )
+        output_path.parent.mkdir(parents=True)
+        output_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        output = self.client.get(
+            "/outputs/inkplate6-landscape/weather.png"
+        )
+        wrong_filename = self.client.get(
+            "/outputs/inkplate6-landscape/calendar.png"
+        )
+        unknown_profile = self.client.get(
+            "/outputs/unknown/weather.png"
+        )
+
+        self.assertEqual(output.status_code, 200)
+        self.assertEqual(wrong_filename.status_code, 404)
+        self.assertEqual(unknown_profile.status_code, 404)
+        output.close()
+
+    def test_legacy_aliases_follow_the_configured_default_profile(self):
+        output_path = self.store.output_path(
+            "inkplate6-landscape",
+            "weather.png",
+        )
+        output_path.parent.mkdir(parents=True)
+        output_path.write_bytes(b"secondary")
+        app = create_app(
+            data_dir=self.temporary_dir.name,
+            output_profiles=self.profiles,
+            default_output_profile="inkplate6-landscape",
+        )
+        app.config["TESTING"] = True
+        client = app.test_client()
+
+        legacy = client.get("/calendar.png")
+        pwa = client.get("/app/calendar.png")
+
+        self.assertEqual(legacy.data, b"secondary")
+        self.assertEqual(pwa.data, b"secondary")
+        legacy.close()
+        pwa.close()
+
     def test_ready_requires_snapshot_and_named_output(self):
         ArtifactStore.write_json(
             self.store.snapshot_path,
@@ -103,11 +196,28 @@ class WebAppTests(unittest.TestCase):
         )
         output_path.parent.mkdir(parents=True)
         output_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+        secondary_path = self.store.output_path(
+            "inkplate6-landscape",
+            "weather.png",
+        )
+        secondary_path.parent.mkdir(parents=True)
+        secondary_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+        snapshot = mock.Mock()
+        snapshot.generated_at.isoformat.return_value = (
+            "2026-06-08T08:46:24+00:00"
+        )
+        self.store.write_ready(snapshot, self.profiles)
 
         response = self.client.get("/api/v1/ready")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get_json()["status"], "ready")
+
+        output_path.write_bytes(b"replacement")
+        response = self.client.get("/api/v1/ready")
+
+        self.assertEqual(response.status_code, 503)
+        self.assertFalse(response.get_json()["producer_cycle_complete"])
 
 
 if __name__ == "__main__":

--- a/server/tests/test_web.py
+++ b/server/tests/test_web.py
@@ -1,0 +1,114 @@
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+SERVER_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SERVER_DIR))
+
+from artifacts import ArtifactStore, DEFAULT_OUTPUT_PROFILE
+from web import create_app
+
+
+class WebAppTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary_dir = tempfile.TemporaryDirectory()
+        self.store = ArtifactStore(self.temporary_dir.name)
+        self.legacy_calendar_served = mock.Mock()
+        self.app = create_app(
+            data_dir=self.temporary_dir.name,
+            legacy_calendar_served=self.legacy_calendar_served,
+        )
+        self.app.config["TESTING"] = True
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.temporary_dir.cleanup()
+
+    def test_health_is_available_without_artifacts(self):
+        response = self.client.get("/api/v1/health")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), {"status": "ok"})
+
+    def test_weather_and_readiness_are_unavailable_without_artifacts(self):
+        weather = self.client.get("/api/v1/weather")
+        ready = self.client.get("/api/v1/ready")
+
+        self.assertEqual(weather.status_code, 503)
+        self.assertEqual(ready.status_code, 503)
+        self.assertEqual(
+            ready.get_json(),
+            {
+                "status": "not_ready",
+                "snapshot": False,
+                "outputs": {DEFAULT_OUTPUT_PROFILE: False},
+            },
+        )
+
+    def test_serves_weather_snapshot_with_cache_validators(self):
+        payload = {
+            "schema_version": "1.0",
+            "generated_at": "2026-06-08T08:46:24+00:00",
+            "current": {},
+            "hourly": [],
+        }
+        ArtifactStore.write_json(self.store.snapshot_path, payload)
+
+        response = self.client.get("/api/v1/weather")
+        conditional = self.client.get(
+            "/api/v1/weather",
+            headers={"If-None-Match": response.headers["ETag"]},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), payload)
+        self.assertIn("no-cache", response.headers["Cache-Control"])
+        self.assertIn("Last-Modified", response.headers)
+        self.assertEqual(conditional.status_code, 304)
+
+    def test_serves_named_output_and_legacy_alias(self):
+        output_path = self.store.output_path(
+            DEFAULT_OUTPUT_PROFILE,
+            "calendar.png",
+        )
+        output_path.parent.mkdir(parents=True)
+        output_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        output = self.client.get(
+            "/outputs/inkplate10-portrait/calendar.png"
+        )
+        legacy = self.client.get("/calendar.png")
+
+        self.assertEqual(output.status_code, 200)
+        self.assertEqual(output.mimetype, "image/png")
+        self.assertNotIn("attachment", output.headers.get("Content-Disposition", ""))
+        self.assertEqual(legacy.status_code, 200)
+        self.assertIn("attachment", legacy.headers["Content-Disposition"])
+        self.legacy_calendar_served.assert_called_once_with()
+        output.close()
+        legacy.close()
+
+    def test_ready_requires_snapshot_and_named_output(self):
+        ArtifactStore.write_json(
+            self.store.snapshot_path,
+            {"schema_version": "1.0"},
+        )
+        output_path = self.store.output_path(
+            DEFAULT_OUTPUT_PROFILE,
+            "calendar.png",
+        )
+        output_path.parent.mkdir(parents=True)
+        output_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        response = self.client.get("/api/v1/ready")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()["status"], "ready")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/tests/test_web_server.py
+++ b/server/tests/test_web_server.py
@@ -1,0 +1,50 @@
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+
+SERVER_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SERVER_DIR))
+
+import web_server
+
+
+class WebServerTests(unittest.TestCase):
+    def test_builds_gunicorn_command_from_server_port(self):
+        argv = web_server.gunicorn_argv({"server": {"port": 9090}})
+
+        self.assertEqual(argv[0:3], [sys.executable, "-m", "gunicorn"])
+        self.assertIn("0.0.0.0:9090", argv)
+        self.assertEqual(argv[-1], "web:app")
+
+    @mock.patch("web_server.os.execv")
+    @mock.patch("web_server.export_output_profiles")
+    @mock.patch(
+        "web_server.load_config",
+        return_value=(pathlib.Path("config.yaml"), {"server": {"enabled": True}}),
+    )
+    def test_execs_gunicorn_for_enabled_server(
+        self,
+        load_config,
+        export_profiles,
+        execv,
+    ):
+        web_server.main()
+
+        export_profiles.assert_called_once()
+        execv.assert_called_once()
+        self.assertEqual(execv.call_args.args[0], sys.executable)
+
+    @mock.patch("web_server.os.execv")
+    @mock.patch(
+        "web_server.load_config",
+        return_value=(pathlib.Path("config.yaml"), {"server": {"enabled": False}}),
+    )
+    def test_does_not_start_gunicorn_for_disabled_server(
+        self,
+        load_config,
+        execv,
+    ):
+        self.assertEqual(web_server.main(), 0)
+        execv.assert_not_called()

--- a/server/views/calendar.py
+++ b/server/views/calendar.py
@@ -7,8 +7,9 @@ class CalendarPage(Page):
         self,
         width,
         height,
+        output_path=None,
     ):
-        super().__init__("calendar", width, height)
+        super().__init__("calendar", width, height, output_path=output_path)
 
     def template(
         self,

--- a/server/views/page.py
+++ b/server/views/page.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from pathlib import Path
 
 from time import sleep
 from airium import Airium
@@ -14,10 +15,12 @@ class Page:
         name,
         width,
         height,
+        output_path=None,
     ):
         self.name = name
         self.image_width = width
         self.image_height = height
+        self.output_path = Path(output_path) if output_path else None
         self.log = logging.getLogger(self.name)
 
         self.airium = Airium()
@@ -32,7 +35,11 @@ class Page:
     def save(self):
         cwd = os.path.dirname(os.path.realpath(__file__))
         html_fp = os.path.join(cwd, "html", self.name + ".html")
-        png_fp = os.path.join(cwd, self.name + ".png")
+        png_fp = self.output_path or Path(cwd, self.name + ".png")
+        png_fp.parent.mkdir(parents=True, exist_ok=True)
+        temporary_png_fp = png_fp.with_name(
+            f".{png_fp.stem}.tmp{png_fp.suffix}"
+        )
 
         with open(html_fp, "wb") as f:
             f.write(bytes(self.airium))
@@ -52,13 +59,19 @@ class Page:
             self._resize_viewport(driver)
             sleep(2)  # Wait for the page to load completely
             self._resize_viewport(driver)
-            driver.save_screenshot(png_fp)
+            if not driver.save_screenshot(str(temporary_png_fp)):
+                raise RuntimeError("WebDriver did not save the screenshot")
+            os.replace(temporary_png_fp, png_fp)
             self.log.info("Screenshot captured and saved to file.")
         except Exception as e:
             self.log.error("Screenshot failed to capture. Error: " + str(e))
             raise
         finally:
             driver.quit()
+            try:
+                temporary_png_fp.unlink()
+            except FileNotFoundError:
+                pass
 
     def _resize_viewport(self, driver):
         viewport = driver.execute_script(

--- a/server/views/pwa/app.js
+++ b/server/views/pwa/app.js
@@ -1,4 +1,4 @@
-const CALENDAR_URL = "/app/calendar.png";
+const CALENDAR_URL = "/outputs/inkplate10-portrait/calendar.png";
 const REFRESH_INTERVAL_MS = 15 * 60 * 1000;
 
 const calendar = document.getElementById("calendar");

--- a/server/views/pwa/app.js
+++ b/server/views/pwa/app.js
@@ -1,4 +1,4 @@
-const CALENDAR_URL = "/outputs/inkplate10-portrait/calendar.png";
+const CALENDAR_URL = "/app/calendar.png";
 const REFRESH_INTERVAL_MS = 15 * 60 * 1000;
 
 const calendar = document.getElementById("calendar");

--- a/server/views/pwa/sw.js
+++ b/server/views/pwa/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "weather-calendar-pwa-v2";
+const CACHE_NAME = "weather-calendar-pwa-v3";
 const APP_SHELL = [
   "/app",
   "/app.css",
@@ -30,7 +30,7 @@ self.addEventListener("activate", event => {
 self.addEventListener("fetch", event => {
   const url = new URL(event.request.url);
 
-  if (url.pathname === "/app/calendar.png") {
+  if (url.pathname === "/outputs/inkplate10-portrait/calendar.png") {
     event.respondWith(fetch(event.request));
     return;
   }

--- a/server/views/pwa/sw.js
+++ b/server/views/pwa/sw.js
@@ -30,7 +30,7 @@ self.addEventListener("activate", event => {
 self.addEventListener("fetch", event => {
   const url = new URL(event.request.url);
 
-  if (url.pathname === "/outputs/inkplate10-portrait/calendar.png") {
+  if (url.pathname === "/app/calendar.png") {
     event.respondWith(fetch(event.request));
     return;
   }

--- a/server/weather/snapshot.py
+++ b/server/weather/snapshot.py
@@ -19,6 +19,7 @@ class WeatherSnapshot:
 
     def to_payload(self):
         return {
+            "schema_version": "1.0",
             "generated_at": self.generated_at.isoformat(),
             "source": self.weather_source,
             "units": "metric" if self.metric else "imperial",

--- a/server/web.py
+++ b/server/web.py
@@ -1,0 +1,164 @@
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from flask import Flask, abort, jsonify, request, send_file, send_from_directory
+
+from artifacts import ArtifactStore, DEFAULT_OUTPUT_PROFILE
+
+
+SERVER_DIR = Path(__file__).resolve().parent
+DEFAULT_DATA_DIR = SERVER_DIR / "data"
+DEFAULT_PWA_DIR = SERVER_DIR / "views" / "pwa"
+
+
+def create_app(data_dir=None, pwa_dir=None, legacy_calendar_served=None):
+    app = Flask(__name__)
+    app.config["ARTIFACT_STORE"] = ArtifactStore(
+        data_dir or os.environ.get("INKPLATE_DATA_DIR", DEFAULT_DATA_DIR)
+    )
+    app.config["PWA_DIR"] = Path(pwa_dir or DEFAULT_PWA_DIR)
+    app.config["LEGACY_CALENDAR_SERVED"] = legacy_calendar_served
+    register_routes(app)
+    return app
+
+
+def register_routes(app):
+    @app.get("/api/v1/health")
+    def health():
+        return jsonify({"status": "ok"})
+
+    @app.get("/api/v1/ready")
+    def ready():
+        store = _store(app)
+        snapshot_exists = store.snapshot_path.is_file()
+        output_exists = _calendar_path(store).is_file()
+        status = "ready" if snapshot_exists and output_exists else "not_ready"
+        response = {
+            "status": status,
+            "snapshot": snapshot_exists,
+            "outputs": {DEFAULT_OUTPUT_PROFILE: output_exists},
+        }
+        return jsonify(response), 200 if status == "ready" else 503
+
+    @app.get("/api/v1/weather")
+    def weather():
+        path = _store(app).snapshot_path
+        if not path.is_file():
+            return jsonify({"error": "weather snapshot is not available"}), 503
+
+        try:
+            with path.open(encoding="utf-8") as snapshot_file:
+                payload = json.load(snapshot_file)
+        except (OSError, json.JSONDecodeError):
+            logging.getLogger("server").exception(
+                "Failed to read weather snapshot from %s", path
+            )
+            return jsonify({"error": "weather snapshot is not available"}), 503
+
+        response = jsonify(payload)
+        stat = path.stat()
+        response.last_modified = datetime.fromtimestamp(
+            stat.st_mtime,
+            tz=timezone.utc,
+        )
+        response.cache_control.no_cache = True
+        response.set_etag(
+            f"{stat.st_mtime_ns}-{stat.st_size}",
+            weak=True,
+        )
+        return response.make_conditional(request)
+
+    @app.get(f"/outputs/{DEFAULT_OUTPUT_PROFILE}/calendar.png")
+    def calendar_output():
+        return _send_calendar(app, as_attachment=False)
+
+    @app.get("/calendar.png")
+    def legacy_calendar_output():
+        response = _send_calendar(app, as_attachment=True)
+        callback = app.config.get("LEGACY_CALENDAR_SERVED")
+        if callback is not None:
+            callback()
+        return response
+
+    @app.get("/")
+    @app.get("/app")
+    @app.get("/app/")
+    @app.get("/app/index.html")
+    def pwa():
+        return send_from_directory(app.config["PWA_DIR"], "index.html")
+
+    @app.get("/app.css")
+    def pwa_css():
+        return send_from_directory(app.config["PWA_DIR"], "app.css")
+
+    @app.get("/app.js")
+    def pwa_js():
+        return send_from_directory(app.config["PWA_DIR"], "app.js")
+
+    @app.get("/manifest.webmanifest")
+    def pwa_manifest():
+        return send_from_directory(
+            app.config["PWA_DIR"],
+            "manifest.webmanifest",
+            mimetype="application/manifest+json",
+        )
+
+    @app.get("/sw.js")
+    def pwa_service_worker():
+        return send_from_directory(
+            app.config["PWA_DIR"],
+            "sw.js",
+            mimetype="application/javascript",
+        )
+
+    @app.get("/icons/<path:filename>")
+    def pwa_icon(filename):
+        return send_from_directory(app.config["PWA_DIR"] / "icons", filename)
+
+    @app.get("/favicon.ico")
+    def favicon():
+        return send_from_directory(
+            app.config["PWA_DIR"] / "icons",
+            "weathercal-favicon.ico",
+            mimetype="image/x-icon",
+        )
+
+    @app.get("/apple-touch-icon.png")
+    @app.get("/apple-touch-icon-precomposed.png")
+    def apple_touch_icon():
+        return send_from_directory(
+            app.config["PWA_DIR"] / "icons",
+            "weathercal-icon-192.png",
+            mimetype="image/png",
+        )
+
+    @app.get("/app/calendar.png")
+    def legacy_pwa_calendar_output():
+        return _send_calendar(app, as_attachment=False)
+
+
+def _store(app):
+    return app.config["ARTIFACT_STORE"]
+
+
+def _calendar_path(store):
+    return store.output_path(DEFAULT_OUTPUT_PROFILE, "calendar.png")
+
+
+def _send_calendar(app, as_attachment):
+    path = _calendar_path(_store(app))
+    if not path.is_file():
+        logging.getLogger("server").error("%s: no such file exists", path)
+        abort(404)
+
+    return send_file(
+        path,
+        mimetype="image/png",
+        as_attachment=as_attachment,
+        download_name="calendar.png" if as_attachment else None,
+        max_age=0,
+        conditional=True,
+    )

--- a/server/web.py
+++ b/server/web.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 from flask import Flask, abort, jsonify, request, send_file, send_from_directory
 
-from artifacts import ArtifactStore, DEFAULT_OUTPUT_PROFILE
+from artifacts import ArtifactStore
+from output_profiles import load_exported_output_profiles
 
 
 SERVER_DIR = Path(__file__).resolve().parent
@@ -14,13 +15,26 @@ DEFAULT_DATA_DIR = SERVER_DIR / "data"
 DEFAULT_PWA_DIR = SERVER_DIR / "views" / "pwa"
 
 
-def create_app(data_dir=None, pwa_dir=None, legacy_calendar_served=None):
+def create_app(
+    data_dir=None,
+    pwa_dir=None,
+    legacy_calendar_served=None,
+    output_profiles=None,
+    default_output_profile=None,
+):
+    if output_profiles is None or default_output_profile is None:
+        configured_profiles, configured_default = load_exported_output_profiles()
+        output_profiles = output_profiles or configured_profiles
+        default_output_profile = default_output_profile or configured_default
+
     app = Flask(__name__)
     app.config["ARTIFACT_STORE"] = ArtifactStore(
         data_dir or os.environ.get("INKPLATE_DATA_DIR", DEFAULT_DATA_DIR)
     )
     app.config["PWA_DIR"] = Path(pwa_dir or DEFAULT_PWA_DIR)
     app.config["LEGACY_CALENDAR_SERVED"] = legacy_calendar_served
+    app.config["OUTPUT_PROFILES"] = output_profiles
+    app.config["DEFAULT_OUTPUT_PROFILE"] = default_output_profile
     register_routes(app)
     return app
 
@@ -34,12 +48,18 @@ def register_routes(app):
     def ready():
         store = _store(app)
         snapshot_exists = store.snapshot_path.is_file()
-        output_exists = _calendar_path(store).is_file()
-        status = "ready" if snapshot_exists and output_exists else "not_ready"
+        output_status = store.output_status(_profiles(app))
+        cycle_complete = all(output_status.values())
+        status = (
+            "ready"
+            if snapshot_exists and cycle_complete
+            else "not_ready"
+        )
         response = {
             "status": status,
             "snapshot": snapshot_exists,
-            "outputs": {DEFAULT_OUTPUT_PROFILE: output_exists},
+            "outputs": output_status,
+            "producer_cycle_complete": cycle_complete,
         }
         return jsonify(response), 200 if status == "ready" else 503
 
@@ -52,6 +72,7 @@ def register_routes(app):
         try:
             with path.open(encoding="utf-8") as snapshot_file:
                 payload = json.load(snapshot_file)
+                stat = os.fstat(snapshot_file.fileno())
         except (OSError, json.JSONDecodeError):
             logging.getLogger("server").exception(
                 "Failed to read weather snapshot from %s", path
@@ -59,7 +80,6 @@ def register_routes(app):
             return jsonify({"error": "weather snapshot is not available"}), 503
 
         response = jsonify(payload)
-        stat = path.stat()
         response.last_modified = datetime.fromtimestamp(
             stat.st_mtime,
             tz=timezone.utc,
@@ -71,13 +91,18 @@ def register_routes(app):
         )
         return response.make_conditional(request)
 
-    @app.get(f"/outputs/{DEFAULT_OUTPUT_PROFILE}/calendar.png")
-    def calendar_output():
-        return _send_calendar(app, as_attachment=False)
+    @app.get("/outputs/<profile>/<filename>")
+    def output(profile, filename):
+        return _send_output(
+            app,
+            profile,
+            filename,
+            as_attachment=False,
+        )
 
     @app.get("/calendar.png")
     def legacy_calendar_output():
-        response = _send_calendar(app, as_attachment=True)
+        response = _send_default_output(app, as_attachment=True)
         callback = app.config.get("LEGACY_CALENDAR_SERVED")
         if callback is not None:
             callback()
@@ -137,19 +162,33 @@ def register_routes(app):
 
     @app.get("/app/calendar.png")
     def legacy_pwa_calendar_output():
-        return _send_calendar(app, as_attachment=False)
+        return _send_default_output(app, as_attachment=False)
 
 
 def _store(app):
     return app.config["ARTIFACT_STORE"]
 
 
-def _calendar_path(store):
-    return store.output_path(DEFAULT_OUTPUT_PROFILE, "calendar.png")
+def _profiles(app):
+    return app.config["OUTPUT_PROFILES"]
 
 
-def _send_calendar(app, as_attachment):
-    path = _calendar_path(_store(app))
+def _send_default_output(app, as_attachment):
+    profile = _profiles(app)[app.config["DEFAULT_OUTPUT_PROFILE"]]
+    return _send_output(
+        app,
+        profile.name,
+        profile.filename,
+        as_attachment=as_attachment,
+    )
+
+
+def _send_output(app, profile_name, filename, as_attachment):
+    profile = _profiles(app).get(profile_name)
+    if profile is None or filename != profile.filename:
+        abort(404)
+
+    path = _store(app).output_path(profile.name, profile.filename)
     if not path.is_file():
         logging.getLogger("server").error("%s: no such file exists", path)
         abort(404)
@@ -158,7 +197,10 @@ def _send_calendar(app, as_attachment):
         path,
         mimetype="image/png",
         as_attachment=as_attachment,
-        download_name="calendar.png" if as_attachment else None,
+        download_name=profile.filename if as_attachment else None,
         max_age=0,
         conditional=True,
     )
+
+
+app = create_app()

--- a/server/web_server.py
+++ b/server/web_server.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from pathlib import Path
+
+from configuration import load_config
+from output_profiles import export_output_profiles, load_output_profiles
+
+
+SERVER_DIR = Path(__file__).resolve().parent
+
+
+def gunicorn_argv(config):
+    port = (config.get("server") or {}).get("port", 8080)
+    workers = int(os.environ.get("INKPLATE_WEB_WORKERS", "1"))
+    threads = int(os.environ.get("INKPLATE_WEB_THREADS", "2"))
+    return [
+        sys.executable,
+        "-m",
+        "gunicorn",
+        "--chdir",
+        str(SERVER_DIR),
+        "--bind",
+        f"0.0.0.0:{port}",
+        "--workers",
+        str(workers),
+        "--threads",
+        str(threads),
+        "--access-logfile",
+        "-",
+        "--error-logfile",
+        "-",
+        "web:app",
+    ]
+
+
+def main():
+    _, config = load_config()
+    if not (config.get("server") or {}).get("enabled", True):
+        return 0
+
+    profiles, default_profile = load_output_profiles(config)
+    export_output_profiles(profiles, default_profile)
+    argv = gunicorn_argv(config)
+    os.execv(sys.executable, argv)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- separate weather/render production from the Gunicorn-hosted Flask web service
- persist atomic weather snapshots and rendered artifacts with profile-aware readiness
- add versioned health, readiness, weather, and named output endpoints while preserving `/calendar.png`
- introduce configurable output profiles and renderer registration for future device-specific and Pillow outputs
- update Docker Compose, standalone container, systemd installer, documentation, and CI smoke coverage

## Impact

Existing Inkplate clients continue using `/calendar.png`. The PWA follows the configured default profile. New clients can select named outputs under `/outputs/<profile>/<filename>`.

Gunicorn defaults to one worker with two threads to limit memory use on Pi-class hardware. Existing `image.width` and `image.height` configuration remains supported when no output profile registry is configured.

## Validation

- `python -m unittest discover -s server/tests -v` (29 tests)
- Python compilation checks for server entrypoints and modules
- `git diff --check`
- live Gunicorn smoke test with two configured output profiles, readiness, named routes, and the legacy default alias
