### PR TITLE
Preserve image assets in native installs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,7 +6,9 @@ permissions:
 on:
   push:
     paths:
+      - 'bin/install_server.py'
       - 'server/**'
+      - 'tests/**'
       - 'Dockerfile'
       - 'docker-compose.yml'
       - '.dockerignore'
@@ -14,7 +16,9 @@ on:
       - '.github/workflows/docker-image.yml'
   pull_request:
     paths:
+      - 'bin/install_server.py'
       - 'server/**'
+      - 'tests/**'
       - 'Dockerfile'
       - 'docker-compose.yml'
       - '.dockerignore'
@@ -27,6 +31,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Test installer helpers
+        run: python3 -m unittest discover -s tests -v
 
       - name: Validate Docker Compose config
         env:

--- a/bin/install_server.py
+++ b/bin/install_server.py
@@ -710,8 +710,6 @@ def install_copy_ignore(repo_root: Path):
         "__pycache__",
         "*.pyc",
         "*.log",
-        "*.png",
-        "*.bmp",
         "netatmo-token.json",
     )
 
@@ -725,6 +723,10 @@ def install_copy_ignore(repo_root: Path):
             ignored.add("config.yaml")
         if relative == Path("server/config"):
             ignored.add("config.yaml")
+        if relative == Path("server/views"):
+            ignored.update({"calendar.png", "calendar.bmp"})
+        if relative == Path("server/views/html"):
+            ignored.update({"calendar.html", "map.png", "map.bmp"})
         return ignored
 
     return ignore

--- a/server/tests/test_installer.py
+++ b/server/tests/test_installer.py
@@ -1,0 +1,44 @@
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+INSTALLER_PATH = REPO_ROOT / "bin" / "install_server.py"
+SPEC = importlib.util.spec_from_file_location("install_server", INSTALLER_PATH)
+install_server = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(install_server)
+
+
+class InstallerCopyTests(unittest.TestCase):
+    def test_preserves_committed_png_assets_and_ignores_generated_images(self):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            root = pathlib.Path(temporary_dir)
+            html_dir = root / "server" / "views" / "html"
+            icon_dir = html_dir / "icon"
+            pwa_icon_dir = root / "server" / "views" / "pwa" / "icons"
+            icon_dir.mkdir(parents=True)
+            pwa_icon_dir.mkdir(parents=True)
+
+            ignore = install_server.install_copy_ignore(root)
+
+            self.assertNotIn(
+                "cloudy.png",
+                ignore(str(icon_dir), ["cloudy.png"]),
+            )
+            self.assertNotIn(
+                "weathercal-icon-192.png",
+                ignore(
+                    str(pwa_icon_dir),
+                    ["weathercal-icon-192.png"],
+                ),
+            )
+            self.assertIn(
+                "map.png",
+                ignore(str(html_dir), ["map.png", "styles.css"]),
+            )
+            self.assertIn(
+                "calendar.html",
+                ignore(str(html_dir), ["calendar.html", "styles.css"]),
+            )

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -4,7 +4,7 @@ import tempfile
 import unittest
 
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 INSTALLER_PATH = REPO_ROOT / "bin" / "install_server.py"
 SPEC = importlib.util.spec_from_file_location("install_server", INSTALLER_PATH)
 install_server = importlib.util.module_from_spec(SPEC)


### PR DESCRIPTION
## Summary

- stop excluding every PNG and BMP during native application copies
- exclude only generated renderer files such as `map.png` and `calendar.png`
- add a regression test proving committed weather and PWA icons are preserved

## Root cause

`install_copy_ignore()` used global `*.png` and `*.bmp` patterns. Native systemd installs therefore omitted the committed weather icon set under `server/views/html/icon`, producing broken-image placeholders in rendered calendars.

## Validation

- `python -m unittest discover -s server/tests -v` (30 tests)
- Python compilation checks
- `git diff --check`
