### PR TITLE
Fix firmware release artifact publishing

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -19,13 +19,18 @@ on:
       - 'bin/generate_firmware_version.py'
       - 'firmware-config.example.yaml'
       - '.github/workflows/firmware.yml'
+  release:
+    types:
+      - published
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      FIRMWARE_VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
 
     steps:
       - name: Checkout repository
@@ -54,11 +59,11 @@ jobs:
         run: |
           # No CONFIG is supplied: release firmware remains the generic
           # SD-card-configured variant.
-          make firmware-compile
+          make firmware-compile FIRMWARE_VERSION="$FIRMWARE_VERSION"
 
       - name: Compile embedded-config firmware
         run: |
-          make firmware-compile CONFIG=firmware-config.example.yaml
+          make firmware-compile CONFIG=firmware-config.example.yaml FIRMWARE_VERSION="$FIRMWARE_VERSION"
 
       - name: Collect firmware binaries
         run: |
@@ -73,17 +78,27 @@ jobs:
           name: inkplate10-firmware
           path: firmware_binaries/*
 
-      - name: Commit and push firmware binaries
-        if: github.event_name == 'push'
+  publish-release:
+    if: github.event_name == 'release'
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download firmware artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: inkplate10-firmware
+          path: firmware_binaries
+
+      - name: Upload firmware release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          git add firmware_binaries/
-
-          if ! git diff-index --quiet HEAD; then
-            git commit -m "chore: update compiled Arduino firmware [skip ci]"
-            git push origin "HEAD:${GITHUB_REF_NAME}"
-          else
-            echo "No changes to the firmware binaries detected."
-          fi
+          gh release upload \
+            "${{ github.event.release.tag_name }}" \
+            firmware_binaries/* \
+            --clobber \
+            --repo "${{ github.repository }}"

--- a/README.md
+++ b/README.md
@@ -342,7 +342,11 @@ make firmware-compile FIRMWARE_FQBN=Inkplate_Boards:esp32:Inkplate10
 
 ### Building with Arduino IDE
 
-The firmware can be compiled correctly on the Arduino IDE. There is a compiled firmware copy that is shared in [Firmware Binaries](firmware_binaries). You may be able to use this to program your board directly, but I would recommend setting up an Arduino IDE with the latest library versions and compiling a version locally.
+The firmware can be compiled correctly on the Arduino IDE. Generic compiled
+firmware is attached to each [GitHub release](../../releases), and CI builds
+also provide a downloadable workflow artifact. You may be able to use a release
+binary to program your board directly, but I would recommend setting up an
+Arduino IDE with the latest library versions and compiling a version locally.
 
 The below assumes you already have a working Arduino environment, configure for the Inkplate10 (with the board definition). The documentation for that is available here :
 


### PR DESCRIPTION
## Summary

Fix Firmware CI failures caused by attempting to commit generated binaries directly to protected branches.

- keep normal push and pull-request firmware builds read-only
- stop committing generated firmware binaries back to `main` or `next`
- build firmware again when a GitHub Release is published
- embed the release tag explicitly in release firmware
- upload generic firmware and partition binaries directly to the GitHub Release
- retain workflow artifacts for normal CI builds
- update README download guidance to point to GitHub Releases and CI artifacts

## Root cause

The firmware workflow used `GITHUB_TOKEN` to commit regenerated binaries after every push. Protected `main` requires changes through a pull request, so the build and artifact upload succeeded but the final direct push was rejected. The generated firmware also embeds the current commit identity, making a commit-back workflow inherently stale after it creates another commit.

## Permissions

The workflow now defaults to `contents: read`. Only the release asset upload job receives `contents: write`, and it writes to the published Release rather than a protected branch.

## Validation

- `git diff --check`
- workflow YAML parsed successfully with PyYAML
- firmware compiled successfully with `FIRMWARE_VERSION=v3.1.0-test`
- verified `v3.1.0-test` is embedded in the generated binary
- verified the installed GitHub CLI supports `gh release upload --clobber`
