### PR TITLE
Remove deprecated Node firmware action

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Arduino CLI
-        uses: arduino/setup-arduino-cli@81d310742121c928ea9c8bbd407b4217b432ae02 # v2.0.0
+      - name: Install Arduino CLI
+        run: make firmware-install-cli
 
       - name: Cache Arduino packages and libraries
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary

Remove the GitHub Actions Node 20 deprecation warning from Firmware CI.

The official `arduino/setup-arduino-cli` action has no newer release and still declares `node20`, including on its default branch. Replace it with the repository's existing pinned installer:

```text
make firmware-install-cli
```

This installs Arduino CLI 1.3.1 under `.tools/`, which the Makefile already prefers automatically.

## Validation

- workflow YAML parses successfully
- `git diff --check`
- installer script passes `bash -n`
- installed CLI reports Arduino CLI 1.3.1
