### PR TITLE
Refactor weather providers and firmware configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,11 @@ WEATHER_API_KEY=replace-with-weather-api-key
 GOOGLE_API_KEY=replace-with-google-api-key
 GOOGLE_STATICMAPS_MAPID=replace-with-google-staticmaps-map-id
 
-# Optional, only when current_temperature.source is netatmo
+# Optional, only when current_conditions.source is netatmo
 NETATMO_CLIENT_ID=
 NETATMO_CLIENT_SECRET=
 NETATMO_REFRESH_TOKEN=
 NETATMO_DEVICE_ID=
 NETATMO_MODULE_ID=
+NETATMO_WIND_MODULE_ID=
+NETATMO_RAIN_MODULE_ID=

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -86,6 +86,7 @@ jobs:
           printf '\211PNG\r\n\032\n' > "$RUNNER_TEMP/inkplate-data/outputs/inkplate10-portrait/calendar.png"
           python3 - <<'PY'
           import json
+          import hashlib
           import os
           from pathlib import Path
 
@@ -93,12 +94,14 @@ jobs:
 
           def artifact(path):
               stat = path.stat()
+              sha256 = hashlib.sha256(path.read_bytes()).hexdigest()
               return {
                   "path": str(path.relative_to(root)),
                   "signature": {
                       "mtime_ns": stat.st_mtime_ns,
                       "size": stat.st_size,
                   },
+                  "sha256": sha256,
               }
 
           ready = {

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -80,7 +80,7 @@ jobs:
             port: 8080
           EOF
           cat > "$RUNNER_TEMP/inkplate-data/weather.json" <<'EOF'
-          {"schema_version":"1.0","generated_at":"2026-06-09T00:00:00+00:00","current":{},"hourly":[]}
+          {"schema_version":"2.0","generated_at":"2026-06-09T00:00:00+00:00","current":{},"hourly":[]}
           EOF
           mkdir -p "$RUNNER_TEMP/inkplate-data/outputs/inkplate10-portrait"
           printf '\211PNG\r\n\032\n' > "$RUNNER_TEMP/inkplate-data/outputs/inkplate10-portrait/calendar.png"

--- a/README.md
+++ b/README.md
@@ -166,9 +166,10 @@ Named outputs are profile-driven. Additional display sizes and renderer
 implementations can be enabled as separate profiles while `/calendar.png`
 continues to serve the configured default.
 
-The server supports AccuWeather and OpenWeatherMap One Call 3.0. One Call 4.0
-is also available as the opt-in `openweathermapv4` provider; it requires
-OpenWeather's separate One Call by Call subscription.
+The server supports AccuWeather and OpenWeatherMap One Call 3.0 and 4.0.
+OpenWeatherMap v2 has been removed. Forecast and optional realtime providers
+use explicit normalized interfaces so additional integrations can be added
+without extending the producer entry point.
 
 ## MQTT
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Likely parameters you'll need to change are:
 - `mqtt_logger.broker` - the MQTT broker reachable from the Inkplate when remote diagnostics are enabled.
 - `mqtt_logger.debug` - publish detailed diagnostics over MQTT; defaults to `false`. Serial logging remains verbose.
 
+The firmware uses the Inkplate RTC between wake cycles and refreshes it from NTP
+at most once every 24 hours. A cold boot, invalid RTC value, or clock moving
+backwards forces an immediate NTP synchronization.
+
 See the [server](/server) for info on server setup.
 
 The server can also expose the rendered calendar as a lightweight browser/PWA

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ display:
   rotation: 1
 calendar:
   url: http://<server-host>:8080/calendar.png
+  status_url: http://<server-host>:8080/api/v1/outputs/inkplate10-portrait/status
   refresh_interval: 3
   retries: 3
 wifi:
@@ -137,6 +138,10 @@ Likely parameters you'll need to change are:
 - `wifi.ssid` - the SSID of your WiFi network.
 - `wifi.pass` - the WiFi password.
 - `calendar.url` - the hostname or IP address of your server which the client will attempt to download the image from. Do not use `localhost` here unless the server is running on the Inkplate itself.
+- `calendar.status_url` - optional small JSON manifest containing the rendered
+  image SHA-256. When it matches the retained signature, the firmware skips the
+  image download and e-paper refresh. Omit it when using an older or third-party
+  server.
 - `calendar.refresh_interval` - how often you want the device to wake up and check for a new image.
 - `ntp.timezone` - the timezone you live in (in "Olson" format), otherwise the client might not wake at the expected time.
 - `mqtt_logger.broker` - the MQTT broker reachable from the Inkplate when remote diagnostics are enabled.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ calendar:
   url: http://<server-host>:8080/calendar.png
   status_url: http://<server-host>:8080/api/v1/outputs/inkplate10-portrait/status
   refresh_interval: 3
-  retries: 3
+  retries: 1
+  retry_interval_minutes: 15
 wifi:
   ssid: XXXX
   pass: XXXX
@@ -143,6 +144,11 @@ Likely parameters you'll need to change are:
   image download and e-paper refresh. Omit it when using an older or third-party
   server.
 - `calendar.refresh_interval` - how often you want the device to wake up and check for a new image.
+- `calendar.retries` - whether to make one immediate image retry while awake.
+  Set to `0` to disable it; values above `1` are accepted for compatibility but
+  still result in only one immediate retry.
+- `calendar.retry_interval_minutes` - deep-sleep interval after both image
+  attempts fail. Defaults to 15 minutes.
 - `ntp.timezone` - the timezone you live in (in "Olson" format), otherwise the client might not wake at the expected time.
 - `mqtt_logger.broker` - the MQTT broker reachable from the Inkplate when remote diagnostics are enabled.
 - `mqtt_logger.debug` - publish detailed diagnostics over MQTT; defaults to `false`. Serial logging remains verbose.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ Both a server and client are required. The main workload is on the server, which
 
 1. Wakes from deep sleep and attempts to connect to WiFi.
 2. Optionally connects to MQTT to publish diagnostic logs.
-3. Attempts to get current network time and update real-time clock.
-4. Downloads and renders the server-hosted PNG directly over HTTP.
+3. Uses the RTC for timekeeping and refreshes it from NTP when synchronization
+   is due.
+4. Optionally checks the output status and downloads the server-hosted PNG only
+   when its content has changed.
 5. Returns to deep sleep for the configured refresh interval.
 
 #### Features:
@@ -39,7 +41,8 @@ Both a server and client are required. The main workload is on the server, which
   - approx 21µA in deep sleep
   - approx 240mA awake
   - approx 30 seconds awake time daily
-- Real-time clock is synchronized from NTP after wake.
+- Real-time clock is normally synchronized from NTP at most once every 24
+  hours; the retained RTC is used between synchronizations.
 - Daylight savings time handled automatically.
 - Battery voltage is checked before WiFi starts; low readings are confirmed
   before a refresh is skipped.
@@ -149,13 +152,20 @@ Likely parameters you'll need to change are:
   still result in only one immediate retry.
 - `calendar.retry_interval_minutes` - deep-sleep interval after both image
   attempts fail. Defaults to 15 minutes.
-- `ntp.timezone` - the timezone you live in (in "Olson" format), otherwise the client might not wake at the expected time.
+- `ntp.timezone` - the timezone used for local timestamps and daylight-saving
+  rules, in Olson format such as `Europe/Dublin`.
 - `mqtt_logger.broker` - the MQTT broker reachable from the Inkplate when remote diagnostics are enabled.
 - `mqtt_logger.debug` - publish detailed diagnostics over MQTT; defaults to `false`. Serial logging remains verbose.
 
 The firmware uses the Inkplate RTC between wake cycles and refreshes it from NTP
 at most once every 24 hours. A cold boot, invalid RTC value, or clock moving
 backwards forces an immediate NTP synchronization.
+
+When `calendar.status_url` is configured, an unchanged SHA-256 skips both the
+PNG download and e-paper update. If the status endpoint is unavailable or
+invalid, the firmware falls back to downloading the image. Failed image
+attempts are limited to one immediate retry before the device returns to deep
+sleep for `calendar.retry_interval_minutes`.
 
 See the [server](/server) for info on server setup.
 
@@ -171,6 +181,7 @@ The server also exposes versioned data and output endpoints:
 /api/v1/weather
 /api/v1/health
 /api/v1/ready
+/api/v1/outputs/inkplate10-portrait/status
 /outputs/inkplate10-portrait/calendar.png
 ```
 

--- a/bin/install_server.py
+++ b/bin/install_server.py
@@ -390,9 +390,12 @@ def collect_answers(env: dict[str, str], config: dict[str, str], mode: str) -> d
     )
     answers["metric"] = prompt_yes_no("Use metric units?", default=parse_bool(config.get("weather.metric", "true")), key="metric")
 
-    current_source = config.get("current_temperature.source", "weather")
+    current_source = config.get(
+        "current_conditions.source",
+        config.get("current_temperature.source", "weather"),
+    )
     answers["netatmo_enabled"] = prompt_yes_no(
-        "Use Netatmo for live current temperature?",
+        "Use Netatmo for live current conditions?",
         default=current_source == "netatmo",
         key="netatmo_enabled",
     )
@@ -401,13 +404,17 @@ def collect_answers(env: dict[str, str], config: dict[str, str], mode: str) -> d
         answers["netatmo_client_secret"] = prompt_secret("Netatmo client secret", default=env.get("NETATMO_CLIENT_SECRET", ""), required=True, key="netatmo_client_secret")
         answers["netatmo_refresh_token"] = prompt_secret("Netatmo refresh token", default=env.get("NETATMO_REFRESH_TOKEN", ""), required=True, key="netatmo_refresh_token")
         answers["netatmo_device_id"] = prompt_text("Netatmo device ID (optional)", default=env.get("NETATMO_DEVICE_ID", ""), required=False, key="netatmo_device_id")
-        answers["netatmo_module_id"] = prompt_text("Netatmo module ID (optional)", default=env.get("NETATMO_MODULE_ID", ""), required=False, key="netatmo_module_id")
+        answers["netatmo_module_id"] = prompt_text("Netatmo temperature/humidity module ID (optional)", default=env.get("NETATMO_MODULE_ID", ""), required=False, key="netatmo_module_id")
+        answers["netatmo_wind_module_id"] = prompt_text("Netatmo wind module ID (optional)", default=env.get("NETATMO_WIND_MODULE_ID", ""), required=False, key="netatmo_wind_module_id")
+        answers["netatmo_rain_module_id"] = prompt_text("Netatmo rain module ID (optional)", default=env.get("NETATMO_RAIN_MODULE_ID", ""), required=False, key="netatmo_rain_module_id")
     else:
         answers["netatmo_client_id"] = env.get("NETATMO_CLIENT_ID", "")
         answers["netatmo_client_secret"] = env.get("NETATMO_CLIENT_SECRET", "")
         answers["netatmo_refresh_token"] = env.get("NETATMO_REFRESH_TOKEN", "")
         answers["netatmo_device_id"] = env.get("NETATMO_DEVICE_ID", "")
         answers["netatmo_module_id"] = env.get("NETATMO_MODULE_ID", "")
+        answers["netatmo_wind_module_id"] = env.get("NETATMO_WIND_MODULE_ID", "")
+        answers["netatmo_rain_module_id"] = env.get("NETATMO_RAIN_MODULE_ID", "")
 
     answers["mqtt_weather_enabled"] = prompt_yes_no(
         "Publish weather data to MQTT?",
@@ -492,7 +499,7 @@ def render_config(answers: dict[str, object], mode: str) -> str:
         "  apikey: ${WEATHER_API_KEY}",
         f"  num_hourly_forecasts: {answers['num_hourly_forecasts']}",
         f"  metric: {yaml_bool(bool(answers['metric']))}",
-        "current_temperature:",
+        "current_conditions:",
         f"  source: {'netatmo' if answers['netatmo_enabled'] else 'weather'}",
         "  netatmo:",
         "    client_id: ${NETATMO_CLIENT_ID:-}",
@@ -501,6 +508,8 @@ def render_config(answers: dict[str, object], mode: str) -> str:
         f"    token_file: {token_file}",
         "    device_id: ${NETATMO_DEVICE_ID:-}",
         "    module_id: ${NETATMO_MODULE_ID:-}",
+        "    wind_module_id: ${NETATMO_WIND_MODULE_ID:-}",
+        "    rain_module_id: ${NETATMO_RAIN_MODULE_ID:-}",
         "google:",
         "  apikey: ${GOOGLE_API_KEY}",
         "  staticmaps_mapid: ${GOOGLE_STATICMAPS_MAPID}",
@@ -549,6 +558,8 @@ def render_env(answers: dict[str, object], include_optional: bool) -> str:
                 "NETATMO_REFRESH_TOKEN": str(answers["netatmo_refresh_token"]),
                 "NETATMO_DEVICE_ID": str(answers["netatmo_device_id"]),
                 "NETATMO_MODULE_ID": str(answers["netatmo_module_id"]),
+                "NETATMO_WIND_MODULE_ID": str(answers["netatmo_wind_module_id"]),
+                "NETATMO_RAIN_MODULE_ID": str(answers["netatmo_rain_module_id"]),
             }
         )
     lines = [

--- a/bin/install_server.py
+++ b/bin/install_server.py
@@ -21,6 +21,20 @@ import time
 from pathlib import Path
 
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_DIR = REPO_ROOT / "server"
+sys.path.insert(0, str(SERVER_DIR))
+
+from output_profiles import (  # noqa: E402
+    DEFAULT_HEIGHT as DEFAULT_IMAGE_HEIGHT,
+    DEFAULT_OUTPUT_FILENAME,
+    DEFAULT_OUTPUT_PROFILE,
+    DEFAULT_RENDERER,
+    DEFAULT_WIDTH as DEFAULT_IMAGE_WIDTH,
+)
+from weather.providers import FORECAST_PROVIDERS  # noqa: E402
+
+
 APP_USER = "inkplate"
 APP_GROUP = "inkplate"
 INSTALL_DIR = Path("/srv/inkplate")
@@ -39,8 +53,11 @@ DEFAULT_REFRESH_HOURS = 3
 DEFAULT_FORECASTS = 6
 DEFAULT_LOCATION = "Landry, FR"
 DEFAULT_WEATHER = "openweathermapv3"
-DEFAULT_IMAGE_WIDTH = 825
-DEFAULT_IMAGE_HEIGHT = 1200
+WEATHER_PROVIDER_LABELS = {
+    "openweathermapv4": "OpenWeatherMap One Call 4.0",
+    "openweathermapv3": "OpenWeatherMap One Call 3.0",
+    "accuweather": "AccuWeather",
+}
 PRIVILEGE_PREFIX: list[str] = []
 INSTALLER_ANSWERS: dict[str, object] = {}
 NON_INTERACTIVE = False
@@ -355,11 +372,7 @@ def collect_answers(env: dict[str, str], config: dict[str, str], mode: str) -> d
     )
     answers["weather_service"] = prompt_choice(
         "Weather provider",
-        [
-            ("openweathermapv4", "OpenWeatherMap One Call 4.0"),
-            ("openweathermapv3", "OpenWeatherMap One Call 3.0"),
-            ("accuweather", "AccuWeather"),
-        ],
+        weather_provider_choices(),
         default=config.get("weather.service", DEFAULT_WEATHER),
         key="weather_service",
     )
@@ -475,6 +488,19 @@ def collect_answers(env: dict[str, str], config: dict[str, str], mode: str) -> d
     return answers
 
 
+def weather_provider_choices() -> list[tuple[str, str]]:
+    ordered_names = [
+        name for name in WEATHER_PROVIDER_LABELS if name in FORECAST_PROVIDERS
+    ]
+    ordered_names.extend(
+        sorted(set(FORECAST_PROVIDERS) - set(ordered_names))
+    )
+    return [
+        (name, WEATHER_PROVIDER_LABELS.get(name, name))
+        for name in ordered_names
+    ]
+
+
 def render_config(answers: dict[str, object], mode: str) -> str:
     token_file = "data/netatmo-token.json" if mode == "docker" else "netatmo-token.json"
     alwayson = "true"
@@ -515,14 +541,14 @@ def render_config(answers: dict[str, object], mode: str) -> str:
         "  staticmaps_mapid: ${GOOGLE_STATICMAPS_MAPID}",
         f"location: {answers['location']}",
         "outputs:",
-        "  default: inkplate10-portrait",
+        f"  default: {DEFAULT_OUTPUT_PROFILE}",
         "  profiles:",
-        "    inkplate10-portrait:",
+        f"    {DEFAULT_OUTPUT_PROFILE}:",
         "      enabled: true",
-        "      renderer: firefox",
+        f"      renderer: {DEFAULT_RENDERER}",
         f"      width: {DEFAULT_IMAGE_WIDTH}",
         f"      height: {DEFAULT_IMAGE_HEIGHT}",
-        "      filename: calendar.png",
+        f"      filename: {DEFAULT_OUTPUT_FILENAME}",
         "mqtt:",
         "  weather:",
         f"    enabled: {yaml_bool(bool(answers['mqtt_weather_enabled']))}",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ x-inkplate-service: &inkplate-service
     NETATMO_REFRESH_TOKEN: ${NETATMO_REFRESH_TOKEN:-}
     NETATMO_DEVICE_ID: ${NETATMO_DEVICE_ID:-}
     NETATMO_MODULE_ID: ${NETATMO_MODULE_ID:-}
+    NETATMO_WIND_MODULE_ID: ${NETATMO_WIND_MODULE_ID:-}
+    NETATMO_RAIN_MODULE_ID: ${NETATMO_RAIN_MODULE_ID:-}
   volumes:
     - ./server/config:/srv/inkplate/server/config:ro
     - inkplate-data:/srv/inkplate/server/data

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -41,6 +41,11 @@ The server publishes after each successful weather refresh. The diagnostic
 listener subscribes when it connects and subscribes again after reconnecting.
 MQTT failures do not stop image rendering or HTTP serving.
 
+Optional realtime-provider fields are included in the retained `/current`
+payload. Netatmo wind data uses `value`, `unit`, and optional `gust` and
+`direction`; rain data uses `value`, `unit`, and optional `last_hour` and
+`last_24_hours`.
+
 Enable diagnostic publishing in the Inkplate configuration, either the SD-card
 `config.yaml` or the YAML passed to `make firmware-upload CONFIG=...`:
 

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -191,7 +191,7 @@ Full snapshot:
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "2.0",
   "generated_at": "2026-06-04T09:00:00+00:00",
   "source": "openweathermapv3",
   "units": "metric",
@@ -216,6 +216,10 @@ Full snapshot:
         "unit": "\u00b0C",
         "value": 18
       },
+      "wind": {
+        "unit": "m/s",
+        "value": 4.2
+      },
       "rain_probability": 100
     }
   ]
@@ -228,6 +232,10 @@ for lightweight display clients. With OpenWeatherMap v4, `current.alerts` is
 also present. Its `active` value indicates whether the current record contains
 alert IDs, and `ids` contains those OpenWeather alert identifiers. Other
 providers may omit this field.
+
+Schema `2.0` standardizes normalized wind measurements on `wind.value`.
+Schema `1.0` clients that consumed the OpenWeatherMap v4-specific `wind.real`
+field must migrate to `wind.value`.
 
 The same canonical payload is available over HTTP at `/api/v1/weather`.
 

--- a/firmware-config.example.yaml
+++ b/firmware-config.example.yaml
@@ -3,6 +3,7 @@ display:
   rotation: 1
 calendar:
   url: http://<server-host>:8080/calendar.png
+  status_url: http://<server-host>:8080/api/v1/outputs/inkplate10-portrait/status
   refresh_interval: 3
   retries: 3
 wifi:

--- a/firmware-config.example.yaml
+++ b/firmware-config.example.yaml
@@ -5,7 +5,8 @@ calendar:
   url: http://<server-host>:8080/calendar.png
   status_url: http://<server-host>:8080/api/v1/outputs/inkplate10-portrait/status
   refresh_interval: 3
-  retries: 3
+  retries: 1
+  retry_interval_minutes: 15
 wifi:
   ssid: your-wifi
   pass: your-wifi-password

--- a/server/EXAMPLE_config.yaml
+++ b/server/EXAMPLE_config.yaml
@@ -12,7 +12,7 @@ weather:
   apikey: ${WEATHER_API_KEY}
   num_hourly_forecasts: 6
   metric: true
-current_temperature:
+current_conditions:
   source: weather # weather or netatmo
   netatmo:
     client_id: ${NETATMO_CLIENT_ID:-}
@@ -21,6 +21,8 @@ current_temperature:
     token_file: netatmo-token.json
     device_id: ${NETATMO_DEVICE_ID:-} # optional; omit to use the first station
     module_id: ${NETATMO_MODULE_ID:-} # optional; omit to use the station indoor temperature
+    wind_module_id: ${NETATMO_WIND_MODULE_ID:-}
+    rain_module_id: ${NETATMO_RAIN_MODULE_ID:-}
 google:
   apikey: ${GOOGLE_API_KEY}
   staticmaps_mapid: ${GOOGLE_STATICMAPS_MAPID}

--- a/server/EXAMPLE_docker_config.yaml
+++ b/server/EXAMPLE_docker_config.yaml
@@ -12,7 +12,7 @@ weather:
   apikey: ${WEATHER_API_KEY}
   num_hourly_forecasts: 6
   metric: true
-current_temperature:
+current_conditions:
   source: weather # weather or netatmo
   netatmo:
     client_id: ${NETATMO_CLIENT_ID:-}
@@ -21,6 +21,8 @@ current_temperature:
     token_file: data/netatmo-token.json
     device_id: ${NETATMO_DEVICE_ID:-}
     module_id: ${NETATMO_MODULE_ID:-}
+    wind_module_id: ${NETATMO_WIND_MODULE_ID:-}
+    rain_module_id: ${NETATMO_RAIN_MODULE_ID:-}
 google:
   apikey: ${GOOGLE_API_KEY}
   staticmaps_mapid: ${GOOGLE_STATICMAPS_MAPID}

--- a/server/README.md
+++ b/server/README.md
@@ -202,11 +202,15 @@ configurations should use `current_conditions`.
 
 Forecast providers implement the normalized `ForecastProvider` interface:
 
-- `get_daily_summary()`
-- `get_hourly_forecast()`
+- `fetch() -> ForecastData`
 
 Realtime providers implement `RealtimeProvider.get_current_conditions()` and
-return a partial current-conditions overlay. Providers are registered in
+return a partial `CurrentConditions` overlay. The supported provider boundary
+uses dataclasses for temperature, wind, rain, current conditions, hourly
+forecasts, and the complete forecast. Renderers and external API clients still
+receive the normalized schema `2.0` dictionary representation.
+
+Providers are registered in
 `weather/providers.py`, which keeps construction, supported names, and lazy
 imports in one place. OpenWeatherMap v2 is no longer registered; supported
 OpenWeatherMap providers are v3 and v4.

--- a/server/README.md
+++ b/server/README.md
@@ -268,6 +268,10 @@ endpoint returns `503` until a snapshot is available. Provider-specific
 optional fields are preserved; for example, OpenWeatherMap v4 active alert IDs
 are exposed under `current.alerts`.
 
+The current payload schema is `2.0`. Wind measurements use `wind.value`;
+the OpenWeatherMap v4-specific `wind.real` field from schema `1.0` has been
+removed.
+
 Generated display artifacts use named output profiles:
 
 ```text

--- a/server/README.md
+++ b/server/README.md
@@ -278,6 +278,17 @@ Generated display artifacts use named output profiles:
 GET /outputs/inkplate10-portrait/calendar.png
 ```
 
+Battery-powered clients can check a small content-hash manifest before
+downloading an output:
+
+```text
+GET /api/v1/outputs/inkplate10-portrait/status
+```
+
+The response includes the output URL and a SHA-256 of its content. The hash
+changes only when the rendered image bytes change, unlike timestamp-based HTTP
+validators.
+
 Output profiles are configured independently:
 
 ```yaml

--- a/server/README.md
+++ b/server/README.md
@@ -112,13 +112,6 @@ In order to obtain an API Key, you will need to:
 
 Make sure you update the config `weather.apikey` with your generated api key and update `weather.service` to `accuweather`.
 
-### OpenWeatherMap API
-
-[DEPRECATED]
-This provider is no longer supported in this version. Use
-[OpenWeatherMapv3](#openweathermapv3-api) or
-[OpenWeatherMapv4](#openweathermapv4-api) instead.
-
 ### OpenWeatherMapv3 API
 
 This is the API that has had the most testing.
@@ -171,19 +164,20 @@ lookup is not currently performed.
 OpenWeatherMap v3 remains the default while v4 output is compared on real
 servers.
 
-### Current temperature source
+### Realtime conditions source
 
-By default the current temperature shown on the display comes from the configured weather provider:
+By default current conditions come from the configured forecast provider:
 
 ```yaml
-current_temperature:
+current_conditions:
   source: weather
 ```
 
-You can optionally use a Netatmo Weather Station for only the current temperature while keeping the configured weather provider for the icon, min/max temperature, hourly forecast, and rain chart:
+You can overlay realtime Netatmo measurements while keeping the configured
+provider for icons, min/max temperature, and hourly forecasts:
 
 ```yaml
-current_temperature:
+current_conditions:
   source: netatmo
   netatmo:
     client_id: ${NETATMO_CLIENT_ID:-}
@@ -191,10 +185,35 @@ current_temperature:
     refresh_token: ${NETATMO_REFRESH_TOKEN:-}
     token_file: netatmo-token.json
     device_id: ${NETATMO_DEVICE_ID:-} # optional; omit to use the first station
-    module_id: ${NETATMO_MODULE_ID:-} # optional; omit to use the station indoor temperature
+    module_id: ${NETATMO_MODULE_ID:-} # optional temperature/humidity module
+    wind_module_id: ${NETATMO_WIND_MODULE_ID:-} # optional wind gauge
+    rain_module_id: ${NETATMO_RAIN_MODULE_ID:-} # optional rain gauge
 ```
 
-The Netatmo integration uses the refresh token to request access tokens and stores refreshed token data in `token_file`. If `module_id` is set, the temperature is read from that module. Otherwise the station `dashboard_data.Temperature` value is used.
+The Netatmo integration uses the refresh token to request access tokens and
+stores refreshed token data in `token_file`. Temperature and humidity are read
+from `module_id`, or from the station when it is omitted. Optional wind and rain
+modules add normalized wind speed, gust, direction, current rain, one-hour
+rainfall, and 24-hour rainfall to the API and MQTT snapshot. The existing
+`current_temperature` configuration key remains accepted for migration, but new
+configurations should use `current_conditions`.
+
+### Provider interfaces
+
+Forecast providers implement the normalized `ForecastProvider` interface:
+
+- `get_daily_summary()`
+- `get_hourly_forecast()`
+
+Realtime providers implement `RealtimeProvider.get_current_conditions()` and
+return a partial current-conditions overlay. Providers are registered in
+`weather/providers.py`, which keeps construction, supported names, and lazy
+imports in one place. OpenWeatherMap v2 is no longer registered; supported
+OpenWeatherMap providers are v3 and v4.
+
+Normalized wind measurements use `value` and `unit`, with optional `gust` and
+`direction`. Normalized rain measurements use `value` and `unit`, with optional
+`last_hour` and `last_24_hours`.
 
 ### MQTT weather publishing
 
@@ -330,6 +349,8 @@ NETATMO_CLIENT_SECRET
 NETATMO_REFRESH_TOKEN
 NETATMO_DEVICE_ID
 NETATMO_MODULE_ID
+NETATMO_WIND_MODULE_ID
+NETATMO_RAIN_MODULE_ID
 ```
 
 Empty runtime values do not satisfy required config placeholders such as
@@ -514,12 +535,14 @@ WEATHER_API_KEY=...
 GOOGLE_API_KEY=...
 GOOGLE_STATICMAPS_MAPID=...
 
-# Optional, only when current_temperature.source is netatmo
+# Optional, only when current_conditions.source is netatmo
 NETATMO_CLIENT_ID=
 NETATMO_CLIENT_SECRET=
 NETATMO_REFRESH_TOKEN=
 NETATMO_DEVICE_ID=
 NETATMO_MODULE_ID=
+NETATMO_WIND_MODULE_ID=
+NETATMO_RAIN_MODULE_ID=
 ```
 
 Compose runs separate `inkplate` web, `producer`, and `diagnostics` services.
@@ -653,7 +676,7 @@ Configure the container with:
 
 Fill in at least `WEATHER_API_KEY`, `GOOGLE_API_KEY`, and
 `GOOGLE_STATICMAPS_MAPID`; leave Netatmo values empty unless
-`current_temperature.source` is set to `netatmo`. The supported variable names
+`current_conditions.source` is set to `netatmo`. The supported variable names
 are listed in `.env.example`.
 
 Do not mount a directory over `/srv/inkplate/server`; that path contains the

--- a/server/README.md
+++ b/server/README.md
@@ -329,12 +329,20 @@ Operational endpoints are:
 ```text
 GET /api/v1/health
 GET /api/v1/ready
+GET /api/v1/outputs/<profile>/status
 ```
 
 Health reports whether the Gunicorn web application is running. Readiness
-returns `200` only when the snapshot and output signatures match the completion
-marker written at the end of a successful producer cycle. During an update or
-after an incomplete first cycle it returns `503`.
+returns `200` only when the snapshot and output signatures and SHA-256 hashes
+match the completion marker written at the end of a successful producer cycle.
+During an update or after an incomplete first cycle it returns `503`. Readiness
+markers created before hashes were added are upgraded in place when their
+recorded file signatures still match, so deployment does not require an
+immediate successful weather-provider request.
+
+The per-output status endpoint returns the completed output's SHA-256 and
+generation time. Firmware can compare that hash with its retained value and
+avoid downloading and driving an unchanged image to the e-paper panel.
 
 Snapshots and rendered outputs use stable paths and are atomically replaced, so
 the data directory does not accumulate historical versions. On startup, the

--- a/server/README.md
+++ b/server/README.md
@@ -102,13 +102,13 @@ group, start a new login session or run `newgrp docker` before retrying.
 
 ### AccuWeather API
 
-This is the least tested API.
+This provider follows AccuWeather's current Core Weather API contract, using
+HTTPS and Bearer authentication. It is covered by mocked contract tests but is
+not exercised against the live API in CI.
  
 In order to obtain an API Key, you will need to:
 1. Sign up to [developer.accuweather.com](https://developer.accuweather.com/).
-2. Create an app in [https://developer.accuweather.com/user/me/apps](https://developer.accuweather.com/user/me/apps).
-3. Enter some details about the app's usage and purpose.
-4. Generate API key.
+2. Select a Core Weather API plan and generate an API key.
 
 Make sure you update the config `weather.apikey` with your generated api key and update `weather.service` to `accuweather`.
 

--- a/server/artifacts.py
+++ b/server/artifacts.py
@@ -56,21 +56,41 @@ class ArtifactStore:
             with self.ready_path.open(encoding="utf-8") as ready_file:
                 ready = json.load(ready_file)
             snapshot = ready["snapshot"]
+            snapshot_path = self.root / snapshot["path"]
+            snapshot_signature = self.file_signature(snapshot_path)
             snapshot_matches = (
                 snapshot["signature"]
-                == self.file_signature(self.root / snapshot["path"])
-                and snapshot["sha256"]
-                == self.file_sha256(self.root / snapshot["path"])
+                == snapshot_signature
+            )
+            upgraded = False
+            if snapshot_matches and "sha256" not in snapshot:
+                snapshot["sha256"] = self.file_sha256(snapshot_path)
+                upgraded = True
+            snapshot_matches = (
+                snapshot_matches
+                and snapshot["sha256"] == self.file_sha256(snapshot_path)
             )
             for name, profile in profiles.items():
                 output = ready["outputs"][name]
                 expected_path = self.output_path(name, profile.filename)
+                output_signature = self.file_signature(expected_path)
+                output_matches = (
+                    self.root / output["path"] == expected_path
+                    and output["signature"] == output_signature
+                )
+                if output_matches and "sha256" not in output:
+                    output["sha256"] = self.file_sha256(expected_path)
+                    upgraded = True
                 status[name] = (
                     snapshot_matches
-                    and self.root / output["path"] == expected_path
-                    and output["signature"] == self.file_signature(expected_path)
+                    and output_matches
                     and output["sha256"] == self.file_sha256(expected_path)
                 )
+            if upgraded:
+                try:
+                    self.write_json(self.ready_path, ready)
+                except OSError:
+                    pass
         except (KeyError, OSError, TypeError, json.JSONDecodeError):
             pass
         return status

--- a/server/artifacts.py
+++ b/server/artifacts.py
@@ -44,6 +44,7 @@ class ArtifactStore:
                 "snapshot": {
                     "path": self.snapshot_path.name,
                     "signature": self.file_signature(self.snapshot_path),
+                    "sha256": self.file_sha256(self.snapshot_path),
                 },
                 "outputs": outputs,
             },
@@ -58,6 +59,8 @@ class ArtifactStore:
             snapshot_matches = (
                 snapshot["signature"]
                 == self.file_signature(self.root / snapshot["path"])
+                and snapshot["sha256"]
+                == self.file_sha256(self.root / snapshot["path"])
             )
             for name, profile in profiles.items():
                 output = ready["outputs"][name]
@@ -66,6 +69,7 @@ class ArtifactStore:
                     snapshot_matches
                     and self.root / output["path"] == expected_path
                     and output["signature"] == self.file_signature(expected_path)
+                    and output["sha256"] == self.file_sha256(expected_path)
                 )
         except (KeyError, OSError, TypeError, json.JSONDecodeError):
             pass

--- a/server/artifacts.py
+++ b/server/artifacts.py
@@ -1,4 +1,5 @@
 import json
+import hashlib
 import os
 import tempfile
 import time
@@ -32,6 +33,7 @@ class ArtifactStore:
             outputs[profile.name] = {
                 "path": str(output_path.relative_to(self.root)),
                 "signature": self.file_signature(output_path),
+                "sha256": self.file_sha256(output_path),
                 "renderer": profile.renderer,
             }
 
@@ -124,6 +126,14 @@ class ArtifactStore:
             "mtime_ns": stat.st_mtime_ns,
             "size": stat.st_size,
         }
+
+    @staticmethod
+    def file_sha256(path):
+        digest = hashlib.sha256()
+        with Path(path).open("rb") as artifact:
+            for block in iter(lambda: artifact.read(64 * 1024), b""):
+                digest.update(block)
+        return digest.hexdigest()
 
 
 def _is_temporary_artifact(path):

--- a/server/config/EXAMPLE_config.yaml
+++ b/server/config/EXAMPLE_config.yaml
@@ -12,7 +12,7 @@ weather:
   apikey: ${WEATHER_API_KEY}
   num_hourly_forecasts: 6
   metric: true
-current_temperature:
+current_conditions:
   source: weather # weather or netatmo
   netatmo:
     client_id: ${NETATMO_CLIENT_ID:-}
@@ -21,6 +21,8 @@ current_temperature:
     token_file: data/netatmo-token.json
     device_id: ${NETATMO_DEVICE_ID:-}
     module_id: ${NETATMO_MODULE_ID:-}
+    wind_module_id: ${NETATMO_WIND_MODULE_ID:-}
+    rain_module_id: ${NETATMO_RAIN_MODULE_ID:-}
 google:
   apikey: ${GOOGLE_API_KEY}
   staticmaps_mapid: ${GOOGLE_STATICMAPS_MAPID}

--- a/server/producer_config.py
+++ b/server/producer_config.py
@@ -1,0 +1,152 @@
+from dataclasses import dataclass
+
+from output_profiles import load_output_profiles
+from utils import get_prop, get_prop_by_keys
+from weather.providers import ConfigurationError
+
+
+@dataclass(frozen=True)
+class ProducerConfig:
+    debug: bool
+    always_on: bool
+    refresh_seconds: int
+    weather_service: str
+    weather_api_key: str
+    weather_metric: bool
+    hourly_forecasts: int
+    location: str
+    google_api_key: str
+    static_maps_id: str
+    realtime_config: dict
+    mqtt_weather_config: dict
+    output_profiles: dict
+    default_output_profile: str
+
+    @classmethod
+    def from_config(cls, config):
+        hourly_forecasts = int(
+            get_prop_by_keys(
+                config,
+                "weather",
+                "num_hourly_forecasts",
+                default=6,
+                required=False,
+            )
+        )
+        if hourly_forecasts < 0:
+            raise ConfigurationError(
+                f"num_hourly_forecasts {hourly_forecasts} must be non-negative"
+            )
+
+        refresh_hours = int(
+            get_prop_by_keys(
+                config,
+                "server",
+                "refreshhours",
+                default=3,
+                required=False,
+            )
+        )
+        if refresh_hours <= 0:
+            raise ConfigurationError(
+                f"server.refreshhours {refresh_hours} must be positive"
+            )
+
+        realtime_config = get_prop(
+            config,
+            "current_conditions",
+            default=None,
+            required=False,
+        )
+        if realtime_config is None:
+            realtime_config = get_prop(
+                config,
+                "current_temperature",
+                default={},
+                required=False,
+            )
+
+        mqtt_config = get_prop(
+            config,
+            "mqtt",
+            default={},
+            required=False,
+        ) or {}
+        output_profiles, default_output_profile = load_output_profiles(config)
+
+        return cls(
+            debug=bool(
+                get_prop(config, "debug", default=False, required=False)
+            ),
+            always_on=bool(
+                get_prop_by_keys(
+                    config,
+                    "server",
+                    "alwayson",
+                    default=False,
+                    required=False,
+                )
+            ),
+            refresh_seconds=refresh_hours * 3600,
+            weather_service=str(
+                get_prop_by_keys(
+                    config,
+                    "weather",
+                    "service",
+                    required=True,
+                )
+            ),
+            weather_api_key=str(
+                get_prop_by_keys(
+                    config,
+                    "weather",
+                    "apikey",
+                    required=True,
+                )
+            ),
+            weather_metric=bool(
+                get_prop_by_keys(
+                    config,
+                    "weather",
+                    "metric",
+                    default=True,
+                    required=False,
+                )
+            ),
+            hourly_forecasts=hourly_forecasts,
+            location=str(
+                get_prop(config, "location", required=True)
+            ).strip(),
+            google_api_key=str(
+                get_prop_by_keys(
+                    config,
+                    "google",
+                    "apikey",
+                    required=True,
+                )
+            ),
+            static_maps_id=str(
+                get_prop_by_keys(
+                    config,
+                    "google",
+                    "staticmaps_mapid",
+                    required=True,
+                )
+            ),
+            realtime_config=realtime_config or {},
+            mqtt_weather_config=(mqtt_config.get("weather") or {}),
+            output_profiles=output_profiles,
+            default_output_profile=default_output_profile,
+        )
+
+
+def producer_enabled(config):
+    return bool(
+        get_prop_by_keys(
+            config,
+            "server",
+            "enabled",
+            default=True,
+            required=False,
+        )
+    )

--- a/server/renderers.py
+++ b/server/renderers.py
@@ -26,8 +26,19 @@ class FirefoxCalendarRenderer:
         page.save()
 
 
-def build_renderer(name):
-    if name == FirefoxCalendarRenderer.name:
-        return FirefoxCalendarRenderer()
+RENDERERS = {
+    FirefoxCalendarRenderer.name: FirefoxCalendarRenderer,
+}
 
-    raise ValueError(f"unsupported output renderer {name!r}")
+
+def build_renderer(name):
+    renderer = RENDERERS.get(name)
+    if renderer is not None:
+        return renderer()
+
+    raise ValueError(
+        "unsupported output renderer {!r}; supported renderers: {}".format(
+            name,
+            ", ".join(sorted(RENDERERS)),
+        )
+    )

--- a/server/server.py
+++ b/server/server.py
@@ -12,6 +12,11 @@ from configuration import load_config
 from output_profiles import load_output_profiles
 from renderers import build_renderer
 from weather.snapshot import WeatherSnapshot
+from weather.providers import (
+    ConfigurationError,
+    build_forecast_provider,
+    build_realtime_provider,
+)
 from google.api import GoogleAPIService
 
 cwd = os.path.dirname(os.path.realpath(__file__))
@@ -37,6 +42,20 @@ def configure_logging(debug):
 def main():
     global log
 
+    try:
+        return run()
+    except (ConfigurationError, KeyError) as exc:
+        if log is None:
+            logging.basicConfig()
+            logging.getLogger("server").error("Configuration error: %s", exc)
+        else:
+            log.error("Configuration error: %s", exc)
+        return 1
+
+
+def run():
+    global log
+
     config_path, config = load_config()
 
     debug = get_prop(config, "debug", default=False)
@@ -50,15 +69,9 @@ def main():
         )
 
     google_apikey = get_prop_by_keys(config, "google", "apikey", required=True)
-    weather_service_type = get_prop_by_keys(config, "weather", "service", required=True)
-    if weather_service_type not in [
-        "accuweather",
-        "openweathermap",
-        "openweathermapv3",
-        "openweathermapv4",
-    ]:
-        log.error(f"not a supported weather service {weather_service_type}")
-        sys.exit(1)
+    weather_service_type = get_prop_by_keys(
+        config, "weather", "service", required=True
+    )
 
     weather_apikey = get_prop_by_keys(config, "weather", "apikey", required=True)
     weather_metric = get_prop_by_keys(config, "weather", "metric", default=True)
@@ -66,10 +79,9 @@ def main():
         config, "weather", "num_hourly_forecasts", default=6
     )
     if weather_num_hourly_forecasts < 0:
-        log.error(
+        raise ConfigurationError(
             f"num_hourly_forecasts {weather_num_hourly_forecasts} must be non-negative"
         )
-        sys.exit(1)
 
     staticmaps_mapid = get_prop_by_keys(
         config, "google", "staticmaps_mapid", required=True
@@ -95,64 +107,32 @@ def main():
         mqtt_config.get("weather", {}) or {}
     )
 
+    weather_svc = build_weather_service(
+        weather_service_type,
+        weather_apikey,
+        location,
+        weather_metric,
+        weather_num_hourly_forecasts,
+    )
+    realtime_svc = build_current_conditions_service(
+        config,
+        weather_metric,
+    )
+
     gapi = GoogleAPIService(google_apikey)
     map_file = os.path.join(cwd, "views", "html", "map.png")
     gapi.save_static_map(staticmaps_mapid, location, map_file)
     map_url = "map.png"
 
-    weather_svc = None
-    if weather_service_type == "accuweather":
-        from weather.accuweather.accuweather import AccuweatherService
-
-        weather_svc = AccuweatherService(
-            weather_apikey,
-            location,
-            metric=weather_metric,
-            num_hours=weather_num_hourly_forecasts,
-        )
-    elif weather_service_type == "openweathermap":
-        log.error(
-            f"{weather_service_type} is no longer supported.   Please use the V3 API (openweathermapv3)"
-        )
-        sys.exit(1)
-
-    elif weather_service_type == "openweathermapv3":
-        from weather.openweathermapv3.openweathermapv3 import OpenWeatherMapv3Service
-
-        weather_svc = OpenWeatherMapv3Service(
-            weather_apikey,
-            location,
-            metric=weather_metric,
-            num_hours=weather_num_hourly_forecasts,
-        )
-    elif weather_service_type == "openweathermapv4":
-        from weather.openweathermapv4.openweathermapv4 import (
-            OpenWeatherMapv4Service,
-        )
-
-        weather_svc = OpenWeatherMapv4Service(
-            weather_apikey,
-            location,
-            metric=weather_metric,
-            num_hours=weather_num_hourly_forecasts,
-        )
-    else:
-        log.error(f"not a supported weather service {weather_service_type}")
-        sys.exit(1)
-
-    current_temperature_svc = build_current_temperature_service(
-        config, weather_metric
-    )
-
     # bail early if http server is not enabled
     if not server_enabled:
-        sys.exit(0)
+        return 0
 
     if server_always_on:
         while True:
             if not produce_artifacts(
                 weather_svc,
-                current_temperature_svc,
+                realtime_svc,
                 weather_service_type,
                 weather_metric,
                 weather_publisher,
@@ -170,7 +150,7 @@ def main():
     else:
         success = produce_artifacts(
             weather_svc,
-            current_temperature_svc,
+            realtime_svc,
             weather_service_type,
             weather_metric,
             weather_publisher,
@@ -179,85 +159,63 @@ def main():
             output_renderers,
             artifact_store,
         )
-        sys.exit(0 if success else 1)
+        return 0 if success else 1
 
 
-def build_current_temperature_service(config, metric):
-    current_temperature_config = get_prop(
-        config, "current_temperature", default={}, required=False
-    )
-    if current_temperature_config is None:
-        current_temperature_config = {}
-
-    source = str(current_temperature_config.get("source", "weather")).lower()
-    if source == "weather":
-        return None
-
-    if source != "netatmo":
-        log.error(f"not a supported current temperature source {source}")
-        sys.exit(1)
-
-    netatmo_config = current_temperature_config.get(
-        "netatmo", current_temperature_config
-    )
-    token_file = netatmo_config.get("token_file", "netatmo-token.json")
-    if not os.path.isabs(token_file):
-        token_file = os.path.join(cwd, token_file)
-
-    from weather.netatmo.netatmo import NetatmoCurrentTemperatureService
-
-    return NetatmoCurrentTemperatureService(
-        client_id=get_required_current_temperature_config(
-            netatmo_config, "client_id"
-        ),
-        client_secret=get_required_current_temperature_config(
-            netatmo_config, "client_secret"
-        ),
-        refresh_token=get_required_current_temperature_config(
-            netatmo_config, "refresh_token"
-        ),
-        token_file=token_file,
-        device_id=get_optional_current_temperature_config(
-            netatmo_config, "device_id"
-        ),
-        module_id=get_optional_current_temperature_config(
-            netatmo_config, "module_id"
-        ),
+def build_weather_service(
+    service_type,
+    apikey,
+    location,
+    metric,
+    num_hourly_forecasts,
+):
+    return build_forecast_provider(
+        service_type,
+        apikey=apikey,
+        location=location,
         metric=metric,
+        num_hours=num_hourly_forecasts,
     )
 
 
-def get_required_current_temperature_config(config, key):
-    if key not in config or config[key] is None or config[key] == "":
-        log.error(f"current_temperature.netatmo.{key} is required")
-        sys.exit(1)
+def build_current_conditions_service(config, metric):
+    realtime_config = get_prop(
+        config,
+        "current_conditions",
+        default=None,
+        required=False,
+    )
+    if realtime_config is None:
+        realtime_config = get_prop(
+            config,
+            "current_temperature",
+            default={},
+            required=False,
+        )
+    return build_realtime_provider(
+        realtime_config,
+        metric=metric,
+        base_dir=os.path.abspath(cwd),
+    )
 
-    return config[key]
 
-
-def get_optional_current_temperature_config(config, key):
-    value = config.get(key)
-    if value == "":
-        return None
-
-    return value
-
-
-def apply_current_temperature_override(daily_summary, current_temperature_svc):
-    if current_temperature_svc is None:
+def apply_current_conditions(daily_summary, realtime_svc):
+    if realtime_svc is None:
         return
 
-    daily_summary["temperature"].update(
-        current_temperature_svc.get_current_temperature()
-    )
+    for key, value in realtime_svc.get_current_conditions().items():
+        if isinstance(value, dict) and isinstance(daily_summary.get(key), dict):
+            daily_summary[key].update(value)
+        else:
+            daily_summary[key] = value
 
 
 def build_weather_snapshot(
-    weather_svc, current_temperature_svc, weather_service_type, weather_metric
+    weather_svc, realtime_svc, weather_service_type, weather_metric
 ):
     daily_summary = weather_svc.get_daily_summary()
     hourly_forecasts = weather_svc.get_hourly_forecast()
-    apply_current_temperature_override(daily_summary, current_temperature_svc)
+    apply_current_conditions(daily_summary, realtime_svc)
 
     return WeatherSnapshot(
         daily_summary=daily_summary,
@@ -295,7 +253,7 @@ def render_outputs(
 
 def produce_artifacts(
     weather_svc,
-    current_temperature_svc,
+    realtime_svc,
     weather_service_type,
     weather_metric,
     weather_publisher,
@@ -308,7 +266,7 @@ def produce_artifacts(
     try:
         snapshot = build_weather_snapshot(
             weather_svc,
-            current_temperature_svc,
+            realtime_svc,
             weather_service_type,
             weather_metric,
         )
@@ -362,4 +320,4 @@ def publish_weather_snapshot(weather_publisher, snapshot):
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/server/server.py
+++ b/server/server.py
@@ -203,7 +203,16 @@ def apply_current_conditions(daily_summary, realtime_svc):
     if realtime_svc is None:
         return
 
-    for key, value in realtime_svc.get_current_conditions().items():
+    try:
+        current_conditions = realtime_svc.get_current_conditions()
+    except Exception as exc:
+        log.warning(
+            "Realtime conditions unavailable; using forecast conditions: %s",
+            exc,
+        )
+        return
+
+    for key, value in current_conditions.items():
         if isinstance(value, dict) and isinstance(daily_summary.get(key), dict):
             daily_summary[key].update(value)
         else:

--- a/server/server.py
+++ b/server/server.py
@@ -12,6 +12,7 @@ from configuration import load_config
 from output_profiles import load_output_profiles
 from renderers import build_renderer
 from weather.snapshot import WeatherSnapshot
+from weather.models import CurrentConditions
 from weather.providers import (
     ConfigurationError,
     build_forecast_provider,
@@ -200,8 +201,14 @@ def build_current_conditions_service(config, metric):
 
 
 def apply_current_conditions(daily_summary, realtime_svc):
+    legacy_dict = isinstance(daily_summary, dict)
+    conditions = (
+        CurrentConditions.from_dict(daily_summary)
+        if legacy_dict
+        else daily_summary
+    )
     if realtime_svc is None:
-        return
+        return conditions
 
     try:
         current_conditions = realtime_svc.get_current_conditions()
@@ -210,27 +217,32 @@ def apply_current_conditions(daily_summary, realtime_svc):
             "Realtime conditions unavailable; using forecast conditions: %s",
             exc,
         )
-        return
+        return conditions
 
-    for key, value in current_conditions.items():
-        if isinstance(value, dict) and isinstance(daily_summary.get(key), dict):
-            daily_summary[key].update(value)
-        else:
-            daily_summary[key] = value
+    if isinstance(current_conditions, dict):
+        current_conditions = CurrentConditions.from_dict(current_conditions)
+    result = conditions.overlay(current_conditions)
+    if legacy_dict:
+        daily_summary.clear()
+        daily_summary.update(result.to_dict())
+    return result
 
 
 def build_weather_snapshot(
     weather_svc, realtime_svc, weather_service_type, weather_metric
 ):
-    daily_summary = weather_svc.get_daily_summary()
-    hourly_forecasts = weather_svc.get_hourly_forecast()
-    apply_current_conditions(daily_summary, realtime_svc)
+    forecast = weather_svc.fetch().validate()
+    forecast.current = apply_current_conditions(
+        forecast.current,
+        realtime_svc,
+    )
 
     return WeatherSnapshot(
-        daily_summary=daily_summary,
-        hourly_forecasts=hourly_forecasts,
+        daily_summary=None,
+        hourly_forecasts=None,
         weather_source=weather_service_type,
         metric=weather_metric,
+        forecast=forecast,
     )
 
 

--- a/server/server.py
+++ b/server/server.py
@@ -5,11 +5,10 @@ import os
 import sys
 import time
 import logging.config
-from utils import get_prop, get_prop_by_keys
 from mqtt_publisher import MqttWeatherPublisher
 from artifacts import ArtifactStore
 from configuration import load_config
-from output_profiles import load_output_profiles
+from producer_config import ProducerConfig, producer_enabled
 from renderers import build_renderer
 from weather.snapshot import WeatherSnapshot
 from weather.models import CurrentConditions
@@ -59,9 +58,14 @@ def run():
 
     config_path, config = load_config()
 
-    debug = get_prop(config, "debug", default=False)
+    debug = bool(config.get("debug", False))
     log = configure_logging(debug)
     log.info(f"Loaded config from {config_path}")
+    if not producer_enabled(config):
+        log.info("Producer is disabled by server.enabled")
+        return 0
+
+    settings = ProducerConfig.from_config(config)
     removed_temporary_files = artifact_store.cleanup_stale_temporary_files()
     if removed_temporary_files:
         log.info(
@@ -69,94 +73,70 @@ def run():
             len(removed_temporary_files),
         )
 
-    google_apikey = get_prop_by_keys(config, "google", "apikey", required=True)
-    weather_service_type = get_prop_by_keys(
-        config, "weather", "service", required=True
-    )
-
-    weather_apikey = get_prop_by_keys(config, "weather", "apikey", required=True)
-    weather_metric = get_prop_by_keys(config, "weather", "metric", default=True)
-    weather_num_hourly_forecasts = get_prop_by_keys(
-        config, "weather", "num_hourly_forecasts", default=6
-    )
-    if weather_num_hourly_forecasts < 0:
-        raise ConfigurationError(
-            f"num_hourly_forecasts {weather_num_hourly_forecasts} must be non-negative"
-        )
-
-    staticmaps_mapid = get_prop_by_keys(
-        config, "google", "staticmaps_mapid", required=True
-    )
-
-    location = get_prop(config, "location", required=True).strip().replace(" ", "")
-
-    server_enabled = get_prop_by_keys(config, "server", "enabled", default=True)
-    server_always_on = get_prop_by_keys(config, "server", "alwayson", default=False)
-    server_refresh_seconds = 3600 * get_prop_by_keys(
-        config, "server", "refreshhours", default=3
-    )
-    output_profiles, default_output_profile = load_output_profiles(config)
-    output_renderers = build_output_renderers(output_profiles)
+    output_renderers = build_output_renderers(settings.output_profiles)
     log.info(
         "Enabled output profiles: %s (default: %s)",
-        ", ".join(output_profiles),
-        default_output_profile,
+        ", ".join(settings.output_profiles),
+        settings.default_output_profile,
     )
 
-    mqtt_config = get_prop(config, "mqtt", default={}, required=False) or {}
     weather_publisher = build_mqtt_weather_publisher(
-        mqtt_config.get("weather", {}) or {}
+        settings.mqtt_weather_config
     )
 
     weather_svc = build_weather_service(
-        weather_service_type,
-        weather_apikey,
-        location,
-        weather_metric,
-        weather_num_hourly_forecasts,
+        settings.weather_service,
+        settings.weather_api_key,
+        settings.location,
+        settings.weather_metric,
+        settings.hourly_forecasts,
     )
-    realtime_svc = build_current_conditions_service(
-        config,
-        weather_metric,
+    realtime_svc = build_realtime_provider(
+        settings.realtime_config,
+        metric=settings.weather_metric,
+        base_dir=os.path.abspath(cwd),
     )
 
-    gapi = GoogleAPIService(google_apikey)
+    gapi = GoogleAPIService(settings.google_api_key)
     map_file = os.path.join(cwd, "views", "html", "map.png")
-    gapi.save_static_map(staticmaps_mapid, location, map_file)
+    gapi.save_static_map(
+        settings.static_maps_id,
+        settings.location,
+        map_file,
+    )
     map_url = "map.png"
 
-    # bail early if http server is not enabled
-    if not server_enabled:
-        return 0
-
-    if server_always_on:
+    if settings.always_on:
         while True:
             if not produce_artifacts(
                 weather_svc,
                 realtime_svc,
-                weather_service_type,
-                weather_metric,
+                settings.weather_service,
+                settings.weather_metric,
                 weather_publisher,
                 map_url,
-                output_profiles,
+                settings.output_profiles,
                 output_renderers,
                 artifact_store,
             ):
                 log.error("Sleeping for 120 seconds before retrying....")
                 time.sleep(120)
                 continue
-            log.info(f"Sleeping for {server_refresh_seconds} seconds before refresh")
-            time.sleep(server_refresh_seconds)
+            log.info(
+                "Sleeping for %s seconds before refresh",
+                settings.refresh_seconds,
+            )
+            time.sleep(settings.refresh_seconds)
 
     else:
         success = produce_artifacts(
             weather_svc,
             realtime_svc,
-            weather_service_type,
-            weather_metric,
+            settings.weather_service,
+            settings.weather_metric,
             weather_publisher,
             map_url,
-            output_profiles,
+            settings.output_profiles,
             output_renderers,
             artifact_store,
         )
@@ -180,19 +160,9 @@ def build_weather_service(
 
 
 def build_current_conditions_service(config, metric):
-    realtime_config = get_prop(
-        config,
-        "current_conditions",
-        default=None,
-        required=False,
-    )
+    realtime_config = config.get("current_conditions")
     if realtime_config is None:
-        realtime_config = get_prop(
-            config,
-            "current_temperature",
-            default={},
-            required=False,
-        )
+        realtime_config = config.get("current_temperature", {})
     return build_realtime_provider(
         realtime_config,
         metric=metric,

--- a/server/tests/test_accuweather.py
+++ b/server/tests/test_accuweather.py
@@ -1,6 +1,7 @@
 import pathlib
 import sys
 import unittest
+from datetime import timedelta
 from unittest import mock
 
 
@@ -63,6 +64,9 @@ class AccuweatherServiceTests(unittest.TestCase):
                 [
                     {
                         "EpochDateTime": 1781510400 + offset * 3600,
+                        "DateTime": (
+                            f"2026-06-15T{10 + offset:02d}:00:00+02:00"
+                        ),
                         "WeatherIcon": 1,
                         "Temperature": {"Value": 12 + offset},
                         "Wind": {"Speed": {"Value": 10}},
@@ -84,6 +88,11 @@ class AccuweatherServiceTests(unittest.TestCase):
 
         self.assertEqual(forecast.current.temperature.value, 12)
         self.assertEqual(len(forecast.hourly), 6)
+        self.assertEqual(forecast.hourly[0].timestamp.hour, 10)
+        self.assertEqual(
+            forecast.hourly[0].timestamp.utcoffset(),
+            timedelta(hours=2),
+        )
         self.assertTrue(all(response.closed for response in responses))
         self.assertTrue(
             all(call.kwargs["timeout"] == 20 for call in get.call_args_list)

--- a/server/tests/test_accuweather.py
+++ b/server/tests/test_accuweather.py
@@ -33,7 +33,7 @@ class AccuweatherServiceTests(unittest.TestCase):
                     "DailyForecasts": [
                         {
                             "Day": {"Icon": 1},
-                            "RealFeelTemperature": {
+                            "Temperature": {
                                 "Minimum": {"Value": 5},
                                 "Maximum": {"Value": 15},
                             },
@@ -45,7 +45,7 @@ class AccuweatherServiceTests(unittest.TestCase):
                 [
                     {
                         "WeatherIcon": 1,
-                        "RealFeelTemperature": {
+                        "Temperature": {
                             "Metric": {"Value": 12},
                             "Imperial": {"Value": 54},
                         },
@@ -64,7 +64,7 @@ class AccuweatherServiceTests(unittest.TestCase):
                     {
                         "EpochDateTime": 1781510400 + offset * 3600,
                         "WeatherIcon": 1,
-                        "RealFeelTemperature": {"Value": 12 + offset},
+                        "Temperature": {"Value": 12 + offset},
                         "Wind": {"Speed": {"Value": 10}},
                         "RelativeHumidity": 65,
                         "RainProbability": 20,
@@ -88,6 +88,34 @@ class AccuweatherServiceTests(unittest.TestCase):
         self.assertTrue(
             all(call.kwargs["timeout"] == 20 for call in get.call_args_list)
         )
+        self.assertTrue(
+            all(
+                call.kwargs["headers"]
+                == {"Authorization": "Bearer weather-key"}
+                for call in get.call_args_list
+            )
+        )
+        self.assertEqual(
+            get.call_args_list[0],
+            mock.call(
+                "https://dataservice.accuweather.com/locations/v1/search",
+                headers={"Authorization": "Bearer weather-key"},
+                params={"q": "Landry,FR"},
+                timeout=20,
+            ),
+        )
+        self.assertEqual(
+            get.call_args_list[1].kwargs["params"],
+            {"metric": True, "details": True},
+        )
+        self.assertEqual(
+            get.call_args_list[2].kwargs["params"],
+            {"details": True},
+        )
+        self.assertEqual(
+            get.call_args_list[3].kwargs["params"],
+            {"metric": True, "details": True},
+        )
 
     @mock.patch("weather.accuweather.accuweather.requests.get")
     def test_non_200_response_is_closed(self, get):
@@ -98,6 +126,10 @@ class AccuweatherServiceTests(unittest.TestCase):
             AccuweatherService("weather-key", "Landry,FR")
 
         self.assertTrue(response.closed)
+        self.assertEqual(
+            get.call_args.kwargs["headers"],
+            {"Authorization": "Bearer weather-key"},
+        )
 
 
 if __name__ == "__main__":

--- a/server/tests/test_accuweather.py
+++ b/server/tests/test_accuweather.py
@@ -1,0 +1,104 @@
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+
+SERVER_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SERVER_DIR))
+
+from weather.accuweather.accuweather import AccuweatherService
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+        self.closed = False
+
+    def json(self):
+        return self.payload
+
+    def close(self):
+        self.closed = True
+
+
+class AccuweatherServiceTests(unittest.TestCase):
+    @mock.patch("weather.accuweather.accuweather.requests.get")
+    def test_fetch_returns_typed_forecast_and_closes_responses(self, get):
+        responses = [
+            FakeResponse([{"Key": "location-key"}]),
+            FakeResponse(
+                {
+                    "DailyForecasts": [
+                        {
+                            "Day": {"Icon": 1},
+                            "RealFeelTemperature": {
+                                "Minimum": {"Value": 5},
+                                "Maximum": {"Value": 15},
+                            },
+                        }
+                    ]
+                }
+            ),
+            FakeResponse(
+                [
+                    {
+                        "WeatherIcon": 1,
+                        "RealFeelTemperature": {
+                            "Metric": {"Value": 12},
+                            "Imperial": {"Value": 54},
+                        },
+                        "Wind": {
+                            "Speed": {
+                                "Metric": {"Value": 10},
+                                "Imperial": {"Value": 6},
+                            }
+                        },
+                        "RelativeHumidity": 65,
+                    }
+                ]
+            ),
+            FakeResponse(
+                [
+                    {
+                        "EpochDateTime": 1781510400 + offset * 3600,
+                        "WeatherIcon": 1,
+                        "RealFeelTemperature": {"Value": 12 + offset},
+                        "Wind": {"Speed": {"Value": 10}},
+                        "RelativeHumidity": 65,
+                        "RainProbability": 20,
+                    }
+                    for offset in range(12)
+                ]
+            ),
+        ]
+        get.side_effect = responses
+        service = AccuweatherService(
+            "weather-key",
+            "Landry,FR",
+            num_hours=6,
+        )
+
+        forecast = service.fetch()
+
+        self.assertEqual(forecast.current.temperature.value, 12)
+        self.assertEqual(len(forecast.hourly), 6)
+        self.assertTrue(all(response.closed for response in responses))
+        self.assertTrue(
+            all(call.kwargs["timeout"] == 20 for call in get.call_args_list)
+        )
+
+    @mock.patch("weather.accuweather.accuweather.requests.get")
+    def test_non_200_response_is_closed(self, get):
+        response = FakeResponse({}, status_code=503)
+        get.return_value = response
+
+        with self.assertRaisesRegex(ValueError, "503"):
+            AccuweatherService("weather-key", "Landry,FR")
+
+        self.assertTrue(response.closed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/tests/test_artifacts.py
+++ b/server/tests/test_artifacts.py
@@ -67,9 +67,47 @@ class ArtifactStoreTests(unittest.TestCase):
                 "8f8cbb7dcf46e0bc7d53265749a6c17d"
                 "116093a6ba95e442764060c76fd4a86c",
             )
+            self.assertEqual(
+                ready["snapshot"]["sha256"],
+                ArtifactStore.file_sha256(store.snapshot_path),
+            )
             self.assertTrue(store.producer_cycle_complete(profiles))
 
             output_path.write_bytes(b"new output")
+
+            self.assertFalse(store.producer_cycle_complete(profiles))
+
+    def test_detects_content_changes_when_file_metadata_is_preserved(self):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            store = ArtifactStore(temporary_dir)
+            snapshot = mock.Mock()
+            snapshot.generated_at.isoformat.return_value = (
+                "2026-06-09T00:00:00+00:00"
+            )
+            snapshot.to_payload.return_value = {"value": "old"}
+            profile = OutputProfile(
+                DEFAULT_OUTPUT_PROFILE,
+                "firefox",
+                825,
+                1200,
+            )
+            profiles = {DEFAULT_OUTPUT_PROFILE: profile}
+
+            store.write_snapshot(snapshot)
+            output_path = store.output_path(
+                DEFAULT_OUTPUT_PROFILE,
+                profile.filename,
+            )
+            output_path.parent.mkdir(parents=True)
+            output_path.write_bytes(b"old")
+            store.write_ready(snapshot, profiles)
+            original_stat = output_path.stat()
+
+            output_path.write_bytes(b"new")
+            os.utime(
+                output_path,
+                ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+            )
 
             self.assertFalse(store.producer_cycle_complete(profiles))
 

--- a/server/tests/test_artifacts.py
+++ b/server/tests/test_artifacts.py
@@ -62,6 +62,11 @@ class ArtifactStoreTests(unittest.TestCase):
                 ready["outputs"][DEFAULT_OUTPUT_PROFILE]["path"],
                 "outputs/inkplate10-portrait/calendar.png",
             )
+            self.assertEqual(
+                ready["outputs"][DEFAULT_OUTPUT_PROFILE]["sha256"],
+                "8f8cbb7dcf46e0bc7d53265749a6c17d"
+                "116093a6ba95e442764060c76fd4a86c",
+            )
             self.assertTrue(store.producer_cycle_complete(profiles))
 
             output_path.write_bytes(b"new output")

--- a/server/tests/test_artifacts.py
+++ b/server/tests/test_artifacts.py
@@ -111,6 +111,104 @@ class ArtifactStoreTests(unittest.TestCase):
 
             self.assertFalse(store.producer_cycle_complete(profiles))
 
+    def test_upgrades_legacy_ready_manifest_when_signatures_match(self):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            store = ArtifactStore(temporary_dir)
+            profile = OutputProfile(
+                DEFAULT_OUTPUT_PROFILE,
+                "firefox",
+                825,
+                1200,
+            )
+            profiles = {DEFAULT_OUTPUT_PROFILE: profile}
+            ArtifactStore.write_json(
+                store.snapshot_path,
+                {"schema_version": "1.0"},
+            )
+            output_path = store.output_path(
+                DEFAULT_OUTPUT_PROFILE,
+                profile.filename,
+            )
+            output_path.parent.mkdir(parents=True)
+            output_path.write_bytes(b"legacy output")
+            ArtifactStore.write_json(
+                store.ready_path,
+                {
+                    "generated_at": "2026-06-09T00:00:00+00:00",
+                    "snapshot": {
+                        "path": store.snapshot_path.name,
+                        "signature": store.file_signature(store.snapshot_path),
+                    },
+                    "outputs": {
+                        DEFAULT_OUTPUT_PROFILE: {
+                            "path": str(output_path.relative_to(store.root)),
+                            "signature": store.file_signature(output_path),
+                            "renderer": profile.renderer,
+                        }
+                    },
+                },
+            )
+
+            self.assertTrue(store.producer_cycle_complete(profiles))
+
+            ready = json.loads(store.ready_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                ready["snapshot"]["sha256"],
+                store.file_sha256(store.snapshot_path),
+            )
+            self.assertEqual(
+                ready["outputs"][DEFAULT_OUTPUT_PROFILE]["sha256"],
+                store.file_sha256(output_path),
+            )
+
+    def test_does_not_upgrade_legacy_manifest_with_changed_output(self):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            store = ArtifactStore(temporary_dir)
+            profile = OutputProfile(
+                DEFAULT_OUTPUT_PROFILE,
+                "firefox",
+                825,
+                1200,
+            )
+            profiles = {DEFAULT_OUTPUT_PROFILE: profile}
+            ArtifactStore.write_json(
+                store.snapshot_path,
+                {"schema_version": "1.0"},
+            )
+            output_path = store.output_path(
+                DEFAULT_OUTPUT_PROFILE,
+                profile.filename,
+            )
+            output_path.parent.mkdir(parents=True)
+            output_path.write_bytes(b"legacy output")
+            output_signature = store.file_signature(output_path)
+            ArtifactStore.write_json(
+                store.ready_path,
+                {
+                    "generated_at": "2026-06-09T00:00:00+00:00",
+                    "snapshot": {
+                        "path": store.snapshot_path.name,
+                        "signature": store.file_signature(store.snapshot_path),
+                    },
+                    "outputs": {
+                        DEFAULT_OUTPUT_PROFILE: {
+                            "path": str(output_path.relative_to(store.root)),
+                            "signature": output_signature,
+                            "renderer": profile.renderer,
+                        }
+                    },
+                },
+            )
+            output_path.write_bytes(b"changed output")
+
+            self.assertFalse(store.producer_cycle_complete(profiles))
+
+            ready = json.loads(store.ready_path.read_text(encoding="utf-8"))
+            self.assertNotIn(
+                "sha256",
+                ready["outputs"][DEFAULT_OUTPUT_PROFILE],
+            )
+
     def test_removes_only_stale_temporary_artifacts(self):
         with tempfile.TemporaryDirectory() as temporary_dir:
             store = ArtifactStore(temporary_dir)

--- a/server/tests/test_artifacts.py
+++ b/server/tests/test_artifacts.py
@@ -23,7 +23,7 @@ class ArtifactStoreTests(unittest.TestCase):
             snapshot.generated_at.isoformat.return_value = (
                 "2026-06-09T00:00:00+00:00"
             )
-            snapshot.to_payload.return_value = {"schema_version": "1.0"}
+            snapshot.to_payload.return_value = {"schema_version": "2.0"}
 
             store.write_snapshot(snapshot)
             output_path = store.output_path(
@@ -44,7 +44,7 @@ class ArtifactStoreTests(unittest.TestCase):
 
             self.assertEqual(
                 json.loads(store.snapshot_path.read_text(encoding="utf-8")),
-                {"schema_version": "1.0"},
+                {"schema_version": "2.0"},
             )
             self.assertEqual(
                 store.output_path(DEFAULT_OUTPUT_PROFILE, "calendar.png"),

--- a/server/tests/test_mqtt.py
+++ b/server/tests/test_mqtt.py
@@ -174,7 +174,7 @@ class MqttWeatherPublisherTests(unittest.TestCase):
         client.publish.return_value = result
         snapshot = mock.Mock()
         snapshot.to_payload.return_value = {
-            "schema_version": "1.0",
+            "schema_version": "2.0",
             "generated_at": "2026-06-05T00:00:00+00:00",
             "source": "test",
             "units": "metric",

--- a/server/tests/test_netatmo.py
+++ b/server/tests/test_netatmo.py
@@ -1,0 +1,101 @@
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+
+SERVER_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SERVER_DIR))
+
+from weather.netatmo.netatmo import NetatmoRealtimeService
+
+
+class NetatmoRealtimeServiceTests(unittest.TestCase):
+    def service(self, metric=True):
+        return NetatmoRealtimeService(
+            client_id="id",
+            client_secret="secret",
+            refresh_token="refresh",
+            token_file=None,
+            device_id="station",
+            module_id="outdoor",
+            wind_module_id="wind",
+            rain_module_id="rain",
+            metric=metric,
+        )
+
+    def stations_data(self):
+        return {
+            "body": {
+                "devices": [
+                    {
+                        "_id": "station",
+                        "modules": [
+                            {
+                                "_id": "outdoor",
+                                "dashboard_data": {
+                                    "Temperature": 12.4,
+                                    "Humidity": 67,
+                                },
+                            },
+                            {
+                                "_id": "wind",
+                                "dashboard_data": {
+                                    "WindStrength": 18,
+                                    "GustStrength": 27,
+                                    "WindAngle": 245,
+                                },
+                            },
+                            {
+                                "_id": "rain",
+                                "dashboard_data": {
+                                    "Rain": 0.4,
+                                    "sum_rain_1": 1.2,
+                                    "sum_rain_24": 4.8,
+                                },
+                            },
+                        ],
+                    }
+                ]
+            }
+        }
+
+    def test_normalizes_all_supported_metric_measurements(self):
+        service = self.service()
+        service._get_stations_data = mock.Mock(return_value=self.stations_data())
+
+        conditions = service.get_current_conditions()
+
+        self.assertEqual(conditions["temperature"]["value"], 12)
+        self.assertEqual(conditions["humidity"], 67)
+        self.assertEqual(
+            conditions["wind"],
+            {
+                "source": "netatmo",
+                "live": True,
+                "unit": "kmh",
+                "value": 18,
+                "gust": 27,
+                "direction": 245,
+            },
+        )
+        self.assertEqual(conditions["rain"]["value"], 0.4)
+        self.assertEqual(conditions["rain"]["last_hour"], 1.2)
+        self.assertEqual(conditions["rain"]["last_24_hours"], 4.8)
+
+    def test_converts_measurements_to_imperial(self):
+        service = self.service(metric=False)
+        service._get_stations_data = mock.Mock(return_value=self.stations_data())
+
+        conditions = service.get_current_conditions()
+
+        self.assertEqual(conditions["temperature"]["unit"], "\N{DEGREE SIGN}F")
+        self.assertEqual(conditions["temperature"]["value"], 54)
+        self.assertEqual(conditions["wind"]["unit"], "mph")
+        self.assertEqual(conditions["wind"]["value"], 11.2)
+        self.assertEqual(conditions["rain"]["unit"], "in")
+        self.assertEqual(conditions["rain"]["last_24_hours"], 0.19)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/tests/test_netatmo.py
+++ b/server/tests/test_netatmo.py
@@ -1,5 +1,7 @@
 import pathlib
 import sys
+import tempfile
+import time
 import unittest
 from unittest import mock
 
@@ -95,6 +97,78 @@ class NetatmoRealtimeServiceTests(unittest.TestCase):
         self.assertEqual(conditions["wind"]["value"], 11.2)
         self.assertEqual(conditions["rain"]["unit"], "in")
         self.assertEqual(conditions["rain"]["last_24_hours"], 0.19)
+
+    @mock.patch("weather.netatmo.netatmo.requests.post")
+    @mock.patch("weather.netatmo.netatmo.requests.get")
+    def test_unauthorized_request_uses_persisted_rotated_refresh_token(
+        self,
+        get,
+        post,
+    ):
+        unauthorized = mock.Mock(status_code=401)
+        successful = mock.Mock(
+            status_code=200,
+            json=mock.Mock(return_value=self.stations_data()),
+        )
+        get.side_effect = [unauthorized, successful]
+        post.return_value = mock.Mock(
+            status_code=200,
+            json=mock.Mock(
+                return_value={
+                    "access_token": "replacement-access",
+                    "refresh_token": "replacement-refresh",
+                    "expires_in": 3600,
+                }
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            token_file = pathlib.Path(temporary_dir) / "token.json"
+            token_file.write_text(
+                '{"access_token": "stale", "refresh_token": "rotated", '
+                f'"expires_at": {time.time() + 3600}}}',
+                encoding="utf-8",
+            )
+            service = self.service()
+            service.token_file = str(token_file)
+
+            self.assertEqual(service._get_stations_data(), self.stations_data())
+
+            saved_token = token_file.read_text(encoding="utf-8")
+
+        self.assertEqual(
+            post.call_args.kwargs["data"]["refresh_token"],
+            "rotated",
+        )
+        self.assertIn('"refresh_token": "replacement-refresh"', saved_token)
+        post.return_value.close.assert_called_once_with()
+        unauthorized.close.assert_called_once_with()
+        successful.close.assert_called_once_with()
+
+    @mock.patch("weather.netatmo.netatmo.requests.post")
+    def test_refresh_preserves_refresh_token_when_response_omits_it(self, post):
+        post.return_value = mock.Mock(
+            status_code=200,
+            json=mock.Mock(
+                return_value={
+                    "access_token": "replacement-access",
+                    "expires_in": 3600,
+                }
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            token_file = pathlib.Path(temporary_dir) / "token.json"
+            service = self.service()
+            service.token_file = str(token_file)
+
+            service._refresh_access_token("rotated")
+
+            self.assertIn(
+                '"refresh_token": "rotated"',
+                token_file.read_text(encoding="utf-8"),
+            )
+        post.return_value.close.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/server/tests/test_netatmo.py
+++ b/server/tests/test_netatmo.py
@@ -68,10 +68,10 @@ class NetatmoRealtimeServiceTests(unittest.TestCase):
 
         conditions = service.get_current_conditions()
 
-        self.assertEqual(conditions["temperature"]["value"], 12)
-        self.assertEqual(conditions["humidity"], 67)
+        self.assertEqual(conditions.temperature.value, 12)
+        self.assertEqual(conditions.humidity, 67)
         self.assertEqual(
-            conditions["wind"],
+            conditions.wind.to_dict(),
             {
                 "source": "netatmo",
                 "live": True,
@@ -81,9 +81,9 @@ class NetatmoRealtimeServiceTests(unittest.TestCase):
                 "direction": 245,
             },
         )
-        self.assertEqual(conditions["rain"]["value"], 0.4)
-        self.assertEqual(conditions["rain"]["last_hour"], 1.2)
-        self.assertEqual(conditions["rain"]["last_24_hours"], 4.8)
+        self.assertEqual(conditions.rain.value, 0.4)
+        self.assertEqual(conditions.rain.last_hour, 1.2)
+        self.assertEqual(conditions.rain.last_24_hours, 4.8)
 
     def test_converts_measurements_to_imperial(self):
         service = self.service(metric=False)
@@ -91,12 +91,12 @@ class NetatmoRealtimeServiceTests(unittest.TestCase):
 
         conditions = service.get_current_conditions()
 
-        self.assertEqual(conditions["temperature"]["unit"], "\N{DEGREE SIGN}F")
-        self.assertEqual(conditions["temperature"]["value"], 54)
-        self.assertEqual(conditions["wind"]["unit"], "mph")
-        self.assertEqual(conditions["wind"]["value"], 11.2)
-        self.assertEqual(conditions["rain"]["unit"], "in")
-        self.assertEqual(conditions["rain"]["last_24_hours"], 0.19)
+        self.assertEqual(conditions.temperature.unit, "\N{DEGREE SIGN}F")
+        self.assertEqual(conditions.temperature.value, 54)
+        self.assertEqual(conditions.wind.unit, "mph")
+        self.assertEqual(conditions.wind.value, 11.2)
+        self.assertEqual(conditions.rain.unit, "in")
+        self.assertEqual(conditions.rain.last_24_hours, 0.19)
 
     @mock.patch("weather.netatmo.netatmo.requests.post")
     @mock.patch("weather.netatmo.netatmo.requests.get")

--- a/server/tests/test_openweathermapv3.py
+++ b/server/tests/test_openweathermapv3.py
@@ -1,0 +1,94 @@
+import pathlib
+import sys
+import unittest
+from datetime import datetime, timezone
+from unittest import mock
+
+
+SERVER_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SERVER_DIR))
+
+from weather.openweathermapv3.openweathermapv3 import OpenWeatherMapv3Service
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+        self.closed = False
+
+    def json(self):
+        return self.payload
+
+    def close(self):
+        self.closed = True
+
+
+class OpenWeatherMapv3ServiceTests(unittest.TestCase):
+    @mock.patch("weather.openweathermapv3.openweathermapv3.requests.get")
+    def test_fetch_reuses_onecall_response_for_current_and_hourly(self, get):
+        geocode = FakeResponse([{"lat": 45.572, "lon": 6.739}])
+        start = int(datetime(2026, 6, 15, tzinfo=timezone.utc).timestamp())
+        onecall = FakeResponse(
+            {
+                "timezone_offset": 7200,
+                "current": {
+                    "temp": 12.4,
+                    "weather": [{"icon": "01d"}],
+                },
+                "daily": [{"temp": {"min": 5.2, "max": 15.4}}],
+                "hourly": [
+                    {
+                        "dt": start + offset * 3600,
+                        "temp": 10 + offset,
+                        "humidity": 60,
+                        "wind_speed": 3.5,
+                        "pop": 0.25,
+                        "weather": [{"icon": "01d"}],
+                    }
+                    for offset in range(24)
+                ],
+            }
+        )
+        get.side_effect = [geocode, onecall]
+        service = OpenWeatherMapv3Service(
+            "weather-key",
+            "Landry,FR",
+            num_hours=6,
+        )
+
+        forecast = service.fetch()
+
+        self.assertEqual(forecast.current.temperature.value, 12)
+        self.assertEqual(len(forecast.hourly), 6)
+        self.assertEqual(
+            [item.temperature.value for item in forecast.hourly],
+            [15, 18, 21, 24, 27, 30],
+        )
+        self.assertTrue(
+            all(
+                item.timestamp.utcoffset().total_seconds() == 7200
+                for item in forecast.hourly
+            )
+        )
+        self.assertEqual(get.call_count, 2)
+        get.assert_has_calls(
+            [
+                mock.call(
+                    "https://api.openweathermap.org/geo/1.0/direct"
+                    "?q=Landry,FR&limit=1&appid=weather-key",
+                    timeout=20,
+                ),
+                mock.call(
+                    "https://api.openweathermap.org/data/3.0/onecall"
+                    "?lat=45.572&lon=6.739&appid=weather-key&units=metric",
+                    timeout=20,
+                ),
+            ]
+        )
+        self.assertTrue(geocode.closed)
+        self.assertTrue(onecall.closed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/tests/test_openweathermapv4.py
+++ b/server/tests/test_openweathermapv4.py
@@ -118,6 +118,9 @@ class OpenWeatherMapv4ServiceTests(unittest.TestCase):
         self.assertTrue(
             all(forecast["wind"]["unit"] == "m/s" for forecast in forecasts)
         )
+        self.assertTrue(
+            all("value" in forecast["wind"] for forecast in forecasts)
+        )
         self.assertEqual(
             [forecast["dt"].strftime("%-I%p").lower() for forecast in forecasts],
             ["12pm", "3pm", "6pm", "9pm", "12am", "3am"],

--- a/server/tests/test_openweathermapv4.py
+++ b/server/tests/test_openweathermapv4.py
@@ -103,6 +103,13 @@ class OpenWeatherMapv4ServiceTests(unittest.TestCase):
             },
         )
 
+    def test_fetch_returns_complete_typed_forecast(self):
+        forecast = self.service.fetch()
+
+        self.assertEqual(forecast.current.temperature.value, 16)
+        self.assertEqual(len(forecast.hourly), 6)
+        self.assertEqual(forecast.hourly[0].wind.unit, "m/s")
+
     def test_follows_hourly_pagination_for_all_six_forecast_slots(self):
         forecasts = self.service.get_hourly_forecast()
 

--- a/server/tests/test_producer_config.py
+++ b/server/tests/test_producer_config.py
@@ -1,0 +1,65 @@
+import pathlib
+import sys
+import unittest
+
+
+SERVER_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SERVER_DIR))
+
+from producer_config import ProducerConfig, producer_enabled
+from weather.providers import ConfigurationError
+
+
+class ProducerConfigTests(unittest.TestCase):
+    def test_applies_defaults_when_optional_sections_are_missing(self):
+        settings = ProducerConfig.from_config(
+            {
+                "server": {},
+                "weather": {
+                    "service": "openweathermapv3",
+                    "apikey": "weather-key",
+                },
+                "google": {
+                    "apikey": "google-key",
+                    "staticmaps_mapid": "map-id",
+                },
+                "location": "Landry, FR",
+            }
+        )
+
+        self.assertFalse(settings.debug)
+        self.assertFalse(settings.always_on)
+        self.assertEqual(settings.refresh_seconds, 3 * 3600)
+        self.assertTrue(settings.weather_metric)
+        self.assertEqual(settings.hourly_forecasts, 6)
+        self.assertEqual(settings.location, "Landry, FR")
+        self.assertEqual(settings.realtime_config, {})
+        self.assertEqual(settings.mqtt_weather_config, {})
+
+    def test_accepts_missing_server_section_when_checking_enabled(self):
+        self.assertTrue(producer_enabled({}))
+        self.assertFalse(producer_enabled({"server": {"enabled": False}}))
+
+    def test_rejects_non_positive_refresh_interval(self):
+        with self.assertRaisesRegex(
+            ConfigurationError,
+            "server.refreshhours 0 must be positive",
+        ):
+            ProducerConfig.from_config(
+                {
+                    "server": {"refreshhours": 0},
+                    "weather": {
+                        "service": "openweathermapv3",
+                        "apikey": "weather-key",
+                    },
+                    "google": {
+                        "apikey": "google-key",
+                        "staticmaps_mapid": "map-id",
+                    },
+                    "location": "Landry, FR",
+                }
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/tests/test_providers.py
+++ b/server/tests/test_providers.py
@@ -1,0 +1,223 @@
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+SERVER_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SERVER_DIR))
+
+import server
+from weather.providers import (
+    ConfigurationError,
+    build_forecast_provider,
+    build_realtime_provider,
+)
+
+
+class ForecastProviderFactoryTests(unittest.TestCase):
+    PROVIDERS = {
+        "accuweather": "weather.accuweather.accuweather.AccuweatherService",
+        "openweathermapv3": (
+            "weather.openweathermapv3.openweathermapv3.OpenWeatherMapv3Service"
+        ),
+        "openweathermapv4": (
+            "weather.openweathermapv4.openweathermapv4.OpenWeatherMapv4Service"
+        ),
+    }
+
+    def test_builds_each_supported_provider(self):
+        for name, class_path in self.PROVIDERS.items():
+            with self.subTest(name=name), mock.patch(class_path) as provider:
+                result = build_forecast_provider(
+                    name,
+                    apikey="key",
+                    location="location",
+                    metric=False,
+                    num_hours=4,
+                )
+
+                self.assertIs(result, provider.return_value)
+                provider.assert_called_once_with(
+                    apikey="key",
+                    location="location",
+                    metric=False,
+                    num_hours=4,
+                )
+
+    def test_rejects_removed_openweathermap_v2_name(self):
+        with self.assertRaisesRegex(
+            ConfigurationError,
+            "openweathermap was removed",
+        ):
+            build_forecast_provider(
+                "openweathermap",
+                apikey="key",
+                location="location",
+            )
+
+    def test_rejects_unknown_provider(self):
+        with self.assertRaisesRegex(
+            ConfigurationError,
+            "unsupported weather.service future-weather",
+        ):
+            build_forecast_provider(
+                "future-weather",
+                apikey="key",
+                location="location",
+            )
+
+    @mock.patch("server.build_forecast_provider")
+    def test_server_weather_factory_delegates_to_registry(self, build_provider):
+        result = server.build_weather_service(
+            "openweathermapv4",
+            "key",
+            "location",
+            True,
+            6,
+        )
+
+        self.assertIs(result, build_provider.return_value)
+        build_provider.assert_called_once_with(
+            "openweathermapv4",
+            apikey="key",
+            location="location",
+            metric=True,
+            num_hours=6,
+        )
+
+
+class RealtimeProviderFactoryTests(unittest.TestCase):
+    def test_weather_source_has_no_overlay(self):
+        self.assertIsNone(build_realtime_provider({"source": "weather"}))
+
+    def test_missing_netatmo_value_raises_configuration_error(self):
+        with self.assertRaisesRegex(
+            ConfigurationError,
+            "current_conditions.netatmo.client_secret is required",
+        ):
+            build_realtime_provider(
+                {
+                    "source": "netatmo",
+                    "netatmo": {
+                        "client_id": "id",
+                        "refresh_token": "refresh",
+                    },
+                }
+            )
+
+    @mock.patch("weather.netatmo.netatmo.NetatmoRealtimeService")
+    def test_builds_netatmo_with_optional_measurement_modules(self, provider):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            result = build_realtime_provider(
+                {
+                    "source": "netatmo",
+                    "netatmo": {
+                        "client_id": "id",
+                        "client_secret": "secret",
+                        "refresh_token": "refresh",
+                        "token_file": "tokens.json",
+                        "device_id": "station",
+                        "module_id": "outdoor",
+                        "wind_module_id": "wind",
+                        "rain_module_id": "rain",
+                    },
+                },
+                metric=True,
+                base_dir=temporary_dir,
+            )
+
+        self.assertIs(result, provider.return_value)
+        provider.assert_called_once_with(
+            client_id="id",
+            client_secret="secret",
+            refresh_token="refresh",
+            token_file=str(pathlib.Path(temporary_dir) / "tokens.json"),
+            device_id="station",
+            module_id="outdoor",
+            wind_module_id="wind",
+            rain_module_id="rain",
+            metric=True,
+        )
+
+
+class CurrentConditionsOverlayTests(unittest.TestCase):
+    def test_partial_overlay_preserves_forecast_temperature_range(self):
+        daily_summary = {
+            "temperature": {
+                "unit": "\N{DEGREE SIGN}C",
+                "value": 10,
+                "min": 5,
+                "max": 15,
+            },
+            "icon": "icon/clear.png",
+        }
+        realtime = mock.Mock()
+        realtime.get_current_conditions.return_value = {
+            "temperature": {
+                "source": "netatmo",
+                "live": True,
+                "unit": "\N{DEGREE SIGN}C",
+                "value": 12,
+            },
+            "humidity": 60,
+        }
+
+        server.apply_current_conditions(daily_summary, realtime)
+
+        self.assertEqual(
+            daily_summary["temperature"],
+            {
+                "source": "netatmo",
+                "live": True,
+                "unit": "\N{DEGREE SIGN}C",
+                "value": 12,
+                "min": 5,
+                "max": 15,
+            },
+        )
+        self.assertEqual(daily_summary["humidity"], 60)
+
+    @mock.patch("server.build_realtime_provider")
+    def test_legacy_current_temperature_config_remains_accepted(
+        self,
+        build_provider,
+    ):
+        config = {
+            "current_temperature": {
+                "source": "netatmo",
+                "netatmo": {
+                    "client_id": "id",
+                },
+            }
+        }
+
+        result = server.build_current_conditions_service(config, metric=True)
+
+        self.assertIs(result, build_provider.return_value)
+        build_provider.assert_called_once_with(
+            config["current_temperature"],
+            metric=True,
+            base_dir=str(SERVER_DIR),
+        )
+
+
+class ProducerConfigurationTests(unittest.TestCase):
+    @mock.patch(
+        "server.run",
+        side_effect=ConfigurationError("invalid provider"),
+    )
+    def test_main_reports_configuration_error_at_process_boundary(self, run):
+        logger = mock.Mock()
+        with mock.patch.object(server, "log", logger):
+            self.assertEqual(server.main(), 1)
+
+        logger.error.assert_called_once_with(
+            "Configuration error: %s",
+            mock.ANY,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/tests/test_server.py
+++ b/server/tests/test_server.py
@@ -114,6 +114,26 @@ class ProducerTests(unittest.TestCase):
             {"layout": "compact"},
         )
 
+    def test_realtime_failure_preserves_forecast_conditions(self):
+        daily_summary = {
+            "temperature": {
+                "unit": "\N{DEGREE SIGN}C",
+                "value": 10,
+                "min": 5,
+                "max": 15,
+            }
+        }
+        realtime = mock.Mock()
+        realtime.get_current_conditions.side_effect = RuntimeError("offline")
+
+        server.apply_current_conditions(daily_summary, realtime)
+
+        self.assertEqual(daily_summary["temperature"]["value"], 10)
+        server.log.warning.assert_called_once_with(
+            "Realtime conditions unavailable; using forecast conditions: %s",
+            mock.ANY,
+        )
+
     @mock.patch("server.render_outputs")
     @mock.patch("server.publish_weather_snapshot")
     @mock.patch("server.build_weather_snapshot")

--- a/server/tests/test_server.py
+++ b/server/tests/test_server.py
@@ -48,6 +48,25 @@ class ProducerTests(unittest.TestCase):
             str(SERVER_DIR / "logging.dev.ini"),
         )
 
+    @mock.patch("server.ProducerConfig.from_config")
+    @mock.patch("server.configure_logging")
+    @mock.patch("server.load_config")
+    def test_disabled_producer_exits_before_loading_provider_configuration(
+        self,
+        load_config,
+        configure_logging,
+        from_config,
+    ):
+        load_config.return_value = (
+            "/config.yaml",
+            {"server": {"enabled": False}},
+        )
+        configure_logging.return_value = mock.Mock()
+
+        self.assertEqual(server.run(), 0)
+
+        from_config.assert_not_called()
+
     def test_rejects_unregistered_renderer_before_production(self):
         profiles = {
             "future": OutputProfile(

--- a/server/tests/test_snapshot.py
+++ b/server/tests/test_snapshot.py
@@ -7,7 +7,7 @@ import unittest
 SERVER_DIR = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SERVER_DIR))
 
-from weather.snapshot import WeatherSnapshot
+from weather.snapshot import SCHEMA_VERSION, WeatherSnapshot
 
 
 class WeatherSnapshotTests(unittest.TestCase):
@@ -19,7 +19,8 @@ class WeatherSnapshotTests(unittest.TestCase):
             generated_at=dt.datetime(2026, 6, 8, tzinfo=dt.timezone.utc),
         )
 
-        self.assertEqual(snapshot.to_payload()["schema_version"], "1.0")
+        self.assertEqual(SCHEMA_VERSION, "2.0")
+        self.assertEqual(snapshot.to_payload()["schema_version"], SCHEMA_VERSION)
 
     def test_payload_preserves_current_weather_alerts(self):
         alerts = {"active": True, "ids": ["alert-id"]}

--- a/server/tests/test_weather_models.py
+++ b/server/tests/test_weather_models.py
@@ -1,0 +1,106 @@
+import datetime as dt
+import pathlib
+import sys
+import unittest
+
+
+SERVER_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SERVER_DIR))
+
+from weather.models import (
+    CurrentConditions,
+    ForecastData,
+    HourlyForecast,
+    Rain,
+    Temperature,
+    Wind,
+)
+
+
+class WeatherModelTests(unittest.TestCase):
+    def test_serializes_normalized_forecast_contract(self):
+        forecast = ForecastData(
+            current=CurrentConditions(
+                icon="icon/clear.png",
+                temperature=Temperature(
+                    unit="\N{DEGREE SIGN}C",
+                    value=12,
+                    minimum=5,
+                    maximum=15,
+                ),
+            ),
+            hourly=[
+                HourlyForecast(
+                    timestamp=dt.datetime(
+                        2026,
+                        6,
+                        15,
+                        12,
+                        tzinfo=dt.timezone.utc,
+                    ),
+                    icon="icon/rain.png",
+                    temperature=Temperature(
+                        unit="\N{DEGREE SIGN}C",
+                        value=13,
+                    ),
+                    wind=Wind(unit="m/s", value=4.2),
+                    humidity=70,
+                    rain_probability=40,
+                )
+            ],
+        ).validate()
+
+        self.assertEqual(forecast.current_dict()["temperature"]["min"], 5)
+        self.assertEqual(forecast.hourly_dicts()[0]["wind"]["value"], 4.2)
+
+    def test_realtime_overlay_preserves_forecast_temperature_range(self):
+        forecast = CurrentConditions(
+            icon="icon/clear.png",
+            temperature=Temperature(
+                unit="\N{DEGREE SIGN}C",
+                value=10,
+                minimum=5,
+                maximum=15,
+            ),
+            wind=Wind(unit="m/s", value=2),
+        )
+        realtime = CurrentConditions(
+            temperature=Temperature(
+                unit="\N{DEGREE SIGN}C",
+                value=12,
+                source="netatmo",
+                live=True,
+            ),
+            wind=Wind(
+                unit="kmh",
+                value=18,
+                source="netatmo",
+                live=True,
+            ),
+            rain=Rain(unit="mm", value=0.4),
+            humidity=67,
+        )
+
+        overlaid = forecast.overlay(realtime)
+
+        self.assertEqual(overlaid.temperature.value, 12)
+        self.assertEqual(overlaid.temperature.minimum, 5)
+        self.assertEqual(overlaid.temperature.maximum, 15)
+        self.assertEqual(overlaid.wind.source, "netatmo")
+        self.assertEqual(overlaid.rain.value, 0.4)
+
+    def test_rejects_incomplete_forecast_contract(self):
+        with self.assertRaisesRegex(ValueError, "require an icon"):
+            ForecastData(
+                current=CurrentConditions(
+                    temperature=Temperature(
+                        unit="\N{DEGREE SIGN}C",
+                        value=12,
+                    )
+                ),
+                hourly=[],
+            ).validate()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/tests/test_web.py
+++ b/server/tests/test_web.py
@@ -73,7 +73,7 @@ class WebAppTests(unittest.TestCase):
 
     def test_serves_weather_snapshot_with_cache_validators(self):
         payload = {
-            "schema_version": "1.0",
+            "schema_version": "2.0",
             "generated_at": "2026-06-08T08:46:24+00:00",
             "current": {
                 "alerts": {
@@ -98,8 +98,8 @@ class WebAppTests(unittest.TestCase):
         self.assertEqual(conditional.status_code, 304)
 
     def test_weather_validator_matches_the_open_file_during_replacement(self):
-        old_payload = {"schema_version": "1.0", "value": "old"}
-        new_payload = {"schema_version": "1.0", "value": "new-and-larger"}
+        old_payload = {"schema_version": "2.0", "value": "old"}
+        new_payload = {"schema_version": "2.0", "value": "new-and-larger"}
         ArtifactStore.write_json(self.store.snapshot_path, old_payload)
         old_size = self.store.snapshot_path.stat().st_size
         original_json_load = json.load
@@ -193,7 +193,7 @@ class WebAppTests(unittest.TestCase):
     def test_ready_requires_snapshot_and_named_output(self):
         ArtifactStore.write_json(
             self.store.snapshot_path,
-            {"schema_version": "1.0"},
+            {"schema_version": "2.0"},
         )
         output_path = self.store.output_path(
             DEFAULT_OUTPUT_PROFILE,

--- a/server/tests/test_web.py
+++ b/server/tests/test_web.py
@@ -167,6 +167,53 @@ class WebAppTests(unittest.TestCase):
         self.assertEqual(unknown_profile.status_code, 404)
         output.close()
 
+    def test_serves_content_hash_status_for_completed_output(self):
+        ArtifactStore.write_json(
+            self.store.snapshot_path,
+            {"schema_version": "2.0"},
+        )
+        output_path = self.store.output_path(
+            DEFAULT_OUTPUT_PROFILE,
+            "calendar.png",
+        )
+        output_path.parent.mkdir(parents=True)
+        output_path.write_bytes(b"calendar image")
+        snapshot = mock.Mock()
+        snapshot.generated_at.isoformat.return_value = (
+            "2026-06-15T10:00:00+00:00"
+        )
+        self.store.write_ready(
+            snapshot,
+            {DEFAULT_OUTPUT_PROFILE: self.profiles[DEFAULT_OUTPUT_PROFILE]},
+        )
+
+        response = self.client.get(
+            f"/api/v1/outputs/{DEFAULT_OUTPUT_PROFILE}/status"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.get_json(),
+            {
+                "profile": DEFAULT_OUTPUT_PROFILE,
+                "filename": "calendar.png",
+                "url": (
+                    "/outputs/inkplate10-portrait/calendar.png"
+                ),
+                "generated_at": "2026-06-15T10:00:00+00:00",
+                "sha256": ArtifactStore.file_sha256(output_path),
+            },
+        )
+
+    def test_output_status_requires_completed_output(self):
+        missing = self.client.get(
+            f"/api/v1/outputs/{DEFAULT_OUTPUT_PROFILE}/status"
+        )
+        unknown = self.client.get("/api/v1/outputs/unknown/status")
+
+        self.assertEqual(missing.status_code, 503)
+        self.assertEqual(unknown.status_code, 404)
+
     def test_legacy_aliases_follow_the_configured_default_profile(self):
         output_path = self.store.output_path(
             "inkplate6-landscape",

--- a/server/utils.py
+++ b/server/utils.py
@@ -11,31 +11,26 @@ def get_by_path(root, items):
     """Access a nested object in root by item sequence."""
     return reduce(operator.getitem, items, root)
 
+
 def get_prop_by_keys(
-    config, *keys, default=None, required=True, dehumanized=False
+    config, *keys, default=None, required=True
 ):
-    val = default
-    found_vals = [get_by_path(config, keys)]
-
-    if len(found_vals) == 0:
-        if default is None and required is True:
-            raise KeyError("{} not in config but is required".format(".".join(keys)))
-    else:
-        val = found_vals[0]
-
-    return val
+    try:
+        return get_by_path(config, keys)
+    except (KeyError, TypeError):
+        if required and default is None:
+            raise KeyError(
+                "{} not in config but is required".format(".".join(keys))
+            ) from None
+        return default
 
 
-def get_prop(config, prop, default=None, required=True, dehumanized=False):
-    val = default
-
-    if prop not in config:
-        if default is None and required is True:
-            raise KeyError("{} not in config but is required".format(prop))
-    else:
-        val = config[prop]
-
-    return val
+def get_prop(config, prop, default=None, required=True):
+    if prop in config:
+        return config[prop]
+    if required and default is None:
+        raise KeyError("{} not in config but is required".format(prop))
+    return default
 
 
 def expand_env_vars(value):

--- a/server/weather/accuweather/accuweather.py
+++ b/server/weather/accuweather/accuweather.py
@@ -25,8 +25,7 @@ class AccuweatherService(WeatherService):
     def get_daily_summary(self):
         is_metric = self.units == "metric"
         path = f"{self.baseurl}/forecasts/v1/daily/1day/{self.location_key}?apikey={self.apikey}&metric={is_metric}&details=true"
-        res = requests.get(path)
-        data = res.json()
+        data = self._get_json(path)
 
         if len(data) == 0:
             raise ValueError("Unexpected response from weather api: {}".format(data))
@@ -56,8 +55,7 @@ class AccuweatherService(WeatherService):
     def get_hourly_forecast(self):
         is_metric = self.units == "metric"
         path = f"{self.baseurl}/forecasts/v1/hourly/12hour/{self.location_key}?apikey={self.apikey}&metric={is_metric}&details=true"
-        res = requests.get(path)
-        data = res.json()
+        data = self._get_json(path)
 
         if len(data) == 0:
             raise ValueError("Unexpected response from weather api: {}".format(data))
@@ -92,8 +90,7 @@ class AccuweatherService(WeatherService):
 
     def _get_current_conditions(self):
         path = f"{self.baseurl}/currentconditions/v1/{self.location_key}?apikey={self.apikey}&details=true"
-        res = requests.get(path)
-        data = res.json()
+        data = self._get_json(path)
 
         if len(data) == 0:
             raise ValueError("Unexpected response from weather api: {}".format(data))
@@ -127,8 +124,7 @@ class AccuweatherService(WeatherService):
         path = (
             f"{self.baseurl}/locations/v1/search?apikey={self.apikey}&q={location}"
         )
-        res = requests.get(path)
-        data = res.json()
+        data = self._get_json(path)
 
         if len(data) == 0:
             raise ValueError("Unexpected response from weather api: {}".format(data))
@@ -136,3 +132,15 @@ class AccuweatherService(WeatherService):
         location_key = data["Key"]
 
         return location_key
+
+    def _get_json(self, url):
+        response = requests.get(url, timeout=20)
+        try:
+            if response.status_code != 200:
+                raise ValueError(
+                    "Non-200 response from weather api: "
+                    f"{response.status_code}"
+                )
+            return response.json()
+        finally:
+            response.close()

--- a/server/weather/accuweather/accuweather.py
+++ b/server/weather/accuweather/accuweather.py
@@ -153,3 +153,12 @@ class AccuweatherService(WeatherService):
             return response.json()
         finally:
             response.close()
+
+
+def build_provider(config):
+    return AccuweatherService(
+        apikey=config["apikey"],
+        location=config["location"],
+        metric=config.get("metric", True),
+        num_hours=config.get("num_hours", 6),
+    )

--- a/server/weather/accuweather/accuweather.py
+++ b/server/weather/accuweather/accuweather.py
@@ -2,6 +2,7 @@ import requests
 from utils import even_select
 from datetime import datetime
 from ..service import WeatherService
+from ..models import ForecastData
 
 
 class AccuweatherService(WeatherService):
@@ -14,6 +15,12 @@ class AccuweatherService(WeatherService):
             metric,
         )
         self.location_key = self._get_location_key(location)
+
+    def fetch(self):
+        return ForecastData.from_dicts(
+            self.get_daily_summary(),
+            self.get_hourly_forecast(),
+        ).validate()
 
     def get_daily_summary(self):
         is_metric = self.units == "metric"

--- a/server/weather/accuweather/accuweather.py
+++ b/server/weather/accuweather/accuweather.py
@@ -9,7 +9,7 @@ class AccuweatherService(WeatherService):
     def __init__(self, apikey, location, num_hours=6, metric=True, mock=False):
         super().__init__(
             apikey,
-            "http://dataservice.accuweather.com",
+            "https://dataservice.accuweather.com",
             "accuweather",
             num_hours,
             metric,
@@ -24,8 +24,11 @@ class AccuweatherService(WeatherService):
 
     def get_daily_summary(self):
         is_metric = self.units == "metric"
-        path = f"{self.baseurl}/forecasts/v1/daily/1day/{self.location_key}?apikey={self.apikey}&metric={is_metric}&details=true"
-        data = self._get_json(path)
+        path = f"{self.baseurl}/forecasts/v1/daily/1day/{self.location_key}"
+        data = self._get_json(
+            path,
+            params={"metric": is_metric, "details": True},
+        )
 
         if len(data) == 0:
             raise ValueError("Unexpected response from weather api: {}".format(data))
@@ -42,8 +45,8 @@ class AccuweatherService(WeatherService):
                 "unit": "\N{DEGREE SIGN}C"
                 if self.units == "metric"
                 else "\N{DEGREE SIGN}F",
-                "min": round(data["RealFeelTemperature"]["Minimum"]["Value"]),
-                "max": round(data["RealFeelTemperature"]["Maximum"]["Value"]),
+                "min": round(data["Temperature"]["Minimum"]["Value"]),
+                "max": round(data["Temperature"]["Maximum"]["Value"]),
                 "value": current_conditions["temperature"]["value"],
             },
             "wind": current_conditions["wind"],
@@ -54,8 +57,11 @@ class AccuweatherService(WeatherService):
 
     def get_hourly_forecast(self):
         is_metric = self.units == "metric"
-        path = f"{self.baseurl}/forecasts/v1/hourly/12hour/{self.location_key}?apikey={self.apikey}&metric={is_metric}&details=true"
-        data = self._get_json(path)
+        path = f"{self.baseurl}/forecasts/v1/hourly/12hour/{self.location_key}"
+        data = self._get_json(
+            path,
+            params={"metric": is_metric, "details": True},
+        )
 
         if len(data) == 0:
             raise ValueError("Unexpected response from weather api: {}".format(data))
@@ -74,7 +80,7 @@ class AccuweatherService(WeatherService):
                 "icon": self.get_icon(entry["WeatherIcon"]),
                 "temperature": {
                     "unit": temp_units,
-                    "value": round(entry["RealFeelTemperature"]["Value"]),
+                    "value": round(entry["Temperature"]["Value"]),
                 },
                 "wind": {
                     "unit": speed_units,
@@ -89,8 +95,8 @@ class AccuweatherService(WeatherService):
         return forecasts
 
     def _get_current_conditions(self):
-        path = f"{self.baseurl}/currentconditions/v1/{self.location_key}?apikey={self.apikey}&details=true"
-        data = self._get_json(path)
+        path = f"{self.baseurl}/currentconditions/v1/{self.location_key}"
+        data = self._get_json(path, params={"details": True})
 
         if len(data) == 0:
             raise ValueError("Unexpected response from weather api: {}".format(data))
@@ -109,7 +115,7 @@ class AccuweatherService(WeatherService):
             "icon": self.get_icon(data["WeatherIcon"]),
             "temperature": {
                 "unit": temp_units,
-                "value": round(data["RealFeelTemperature"][units_key]["Value"]),
+                "value": round(data["Temperature"][units_key]["Value"]),
             },
             "wind": {
                 "unit": speed_units,
@@ -121,10 +127,8 @@ class AccuweatherService(WeatherService):
         return conditions
 
     def _get_location_key(self, location):
-        path = (
-            f"{self.baseurl}/locations/v1/search?apikey={self.apikey}&q={location}"
-        )
-        data = self._get_json(path)
+        path = f"{self.baseurl}/locations/v1/search"
+        data = self._get_json(path, params={"q": location})
 
         if len(data) == 0:
             raise ValueError("Unexpected response from weather api: {}".format(data))
@@ -133,8 +137,13 @@ class AccuweatherService(WeatherService):
 
         return location_key
 
-    def _get_json(self, url):
-        response = requests.get(url, timeout=20)
+    def _get_json(self, url, params=None):
+        response = requests.get(
+            url,
+            headers={"Authorization": f"Bearer {self.apikey}"},
+            params=params,
+            timeout=20,
+        )
         try:
             if response.status_code != 200:
                 raise ValueError(

--- a/server/weather/accuweather/accuweather.py
+++ b/server/weather/accuweather/accuweather.py
@@ -76,7 +76,9 @@ class AccuweatherService(WeatherService):
         forecasts = []
         for entry in even_select(self.num_hours, data):
             forecast = {
-                "dt": datetime.fromtimestamp(entry["EpochDateTime"]),
+                "dt": datetime.fromisoformat(
+                    entry["DateTime"].replace("Z", "+00:00")
+                ),
                 "icon": self.get_icon(entry["WeatherIcon"]),
                 "temperature": {
                     "unit": temp_units,

--- a/server/weather/models.py
+++ b/server/weather/models.py
@@ -1,0 +1,278 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass
+class Temperature:
+    unit: str
+    value: float
+    minimum: float | None = None
+    maximum: float | None = None
+    source: str | None = None
+    live: bool = False
+
+    def to_dict(self):
+        value = {"unit": self.unit, "value": self.value}
+        if self.minimum is not None:
+            value["min"] = self.minimum
+        if self.maximum is not None:
+            value["max"] = self.maximum
+        if self.source is not None:
+            value["source"] = self.source
+        if self.live:
+            value["live"] = True
+        return value
+
+    @classmethod
+    def from_dict(cls, value):
+        return cls(
+            unit=value["unit"],
+            value=value["value"],
+            minimum=value.get("min"),
+            maximum=value.get("max"),
+            source=value.get("source"),
+            live=value.get("live", False),
+        )
+
+    def overlay(self, other):
+        return Temperature(
+            unit=other.unit,
+            value=other.value,
+            minimum=(
+                other.minimum
+                if other.minimum is not None
+                else self.minimum
+            ),
+            maximum=(
+                other.maximum
+                if other.maximum is not None
+                else self.maximum
+            ),
+            source=other.source,
+            live=other.live,
+        )
+
+
+@dataclass
+class Wind:
+    unit: str
+    value: float
+    gust: float | None = None
+    direction: float | None = None
+    source: str | None = None
+    live: bool = False
+
+    def to_dict(self):
+        value = {"unit": self.unit, "value": self.value}
+        for key, item in (
+            ("gust", self.gust),
+            ("direction", self.direction),
+            ("source", self.source),
+        ):
+            if item is not None:
+                value[key] = item
+        if self.live:
+            value["live"] = True
+        return value
+
+    @classmethod
+    def from_dict(cls, value):
+        return cls(
+            unit=value["unit"],
+            value=value["value"],
+            gust=value.get("gust"),
+            direction=value.get("direction"),
+            source=value.get("source"),
+            live=value.get("live", False),
+        )
+
+
+@dataclass
+class Rain:
+    unit: str
+    value: float
+    last_hour: float | None = None
+    last_24_hours: float | None = None
+    source: str | None = None
+    live: bool = False
+
+    def to_dict(self):
+        value = {"unit": self.unit, "value": self.value}
+        for key, item in (
+            ("last_hour", self.last_hour),
+            ("last_24_hours", self.last_24_hours),
+            ("source", self.source),
+        ):
+            if item is not None:
+                value[key] = item
+        if self.live:
+            value["live"] = True
+        return value
+
+    @classmethod
+    def from_dict(cls, value):
+        return cls(
+            unit=value["unit"],
+            value=value["value"],
+            last_hour=value.get("last_hour"),
+            last_24_hours=value.get("last_24_hours"),
+            source=value.get("source"),
+            live=value.get("live", False),
+        )
+
+
+@dataclass
+class CurrentConditions:
+    icon: str | None = None
+    temperature: Temperature | None = None
+    wind: Wind | None = None
+    rain: Rain | None = None
+    humidity: float | None = None
+    alerts: dict | None = None
+    extra: dict = field(default_factory=dict)
+
+    def to_dict(self):
+        value = dict(self.extra)
+        for key, item in (
+            ("icon", self.icon),
+            ("humidity", self.humidity),
+            ("alerts", self.alerts),
+        ):
+            if item is not None:
+                value[key] = item
+        if self.temperature is not None:
+            value["temperature"] = self.temperature.to_dict()
+        if self.wind is not None:
+            value["wind"] = self.wind.to_dict()
+        if self.rain is not None:
+            value["rain"] = self.rain.to_dict()
+        return value
+
+    @classmethod
+    def from_dict(cls, value):
+        known = {
+            "icon",
+            "temperature",
+            "wind",
+            "rain",
+            "humidity",
+            "alerts",
+        }
+        return cls(
+            icon=value.get("icon"),
+            temperature=(
+                Temperature.from_dict(value["temperature"])
+                if value.get("temperature") is not None
+                else None
+            ),
+            wind=(
+                Wind.from_dict(value["wind"])
+                if value.get("wind") is not None
+                else None
+            ),
+            rain=(
+                Rain.from_dict(value["rain"])
+                if value.get("rain") is not None
+                else None
+            ),
+            humidity=value.get("humidity"),
+            alerts=value.get("alerts"),
+            extra={key: item for key, item in value.items() if key not in known},
+        )
+
+    def overlay(self, other):
+        temperature = self.temperature
+        if other.temperature is not None:
+            temperature = (
+                self.temperature.overlay(other.temperature)
+                if self.temperature is not None
+                else other.temperature
+            )
+        return CurrentConditions(
+            icon=other.icon if other.icon is not None else self.icon,
+            temperature=temperature,
+            wind=other.wind if other.wind is not None else self.wind,
+            rain=other.rain if other.rain is not None else self.rain,
+            humidity=(
+                other.humidity
+                if other.humidity is not None
+                else self.humidity
+            ),
+            alerts=other.alerts if other.alerts is not None else self.alerts,
+            extra={**self.extra, **other.extra},
+        )
+
+
+@dataclass
+class HourlyForecast:
+    timestamp: datetime
+    icon: str
+    temperature: Temperature
+    rain_probability: float
+    wind: Wind | None = None
+    humidity: float | None = None
+    extra: dict = field(default_factory=dict)
+
+    def to_dict(self):
+        value = {
+            **self.extra,
+            "dt": self.timestamp,
+            "icon": self.icon,
+            "temperature": self.temperature.to_dict(),
+            "rain_probability": self.rain_probability,
+        }
+        if self.wind is not None:
+            value["wind"] = self.wind.to_dict()
+        if self.humidity is not None:
+            value["humidity"] = self.humidity
+        return value
+
+    @classmethod
+    def from_dict(cls, value):
+        known = {
+            "dt",
+            "icon",
+            "temperature",
+            "rain_probability",
+            "wind",
+            "humidity",
+        }
+        return cls(
+            timestamp=value["dt"],
+            icon=value["icon"],
+            temperature=Temperature.from_dict(value["temperature"]),
+            rain_probability=value["rain_probability"],
+            wind=(
+                Wind.from_dict(value["wind"])
+                if value.get("wind") is not None
+                else None
+            ),
+            humidity=value.get("humidity"),
+            extra={key: item for key, item in value.items() if key not in known},
+        )
+
+
+@dataclass
+class ForecastData:
+    current: CurrentConditions
+    hourly: list[HourlyForecast]
+
+    def validate(self):
+        if self.current.icon is None:
+            raise ValueError("forecast current conditions require an icon")
+        if self.current.temperature is None:
+            raise ValueError("forecast current conditions require temperature")
+        return self
+
+    @classmethod
+    def from_dicts(cls, current, hourly):
+        return cls(
+            current=CurrentConditions.from_dict(current),
+            hourly=[HourlyForecast.from_dict(item) for item in hourly],
+        )
+
+    def current_dict(self):
+        return self.current.to_dict()
+
+    def hourly_dicts(self):
+        return [forecast.to_dict() for forecast in self.hourly]

--- a/server/weather/netatmo/netatmo.py
+++ b/server/weather/netatmo/netatmo.py
@@ -2,11 +2,14 @@ import json
 import os
 import tempfile
 import time
+from os.path import isabs
+from pathlib import Path
 
 import requests
 
 from ..service import RealtimeProvider
 from ..models import CurrentConditions, Rain, Temperature, Wind
+from ..service import ProviderConfigurationError
 
 
 class NetatmoRealtimeService(RealtimeProvider):
@@ -276,3 +279,35 @@ class NetatmoRealtimeService(RealtimeProvider):
 
 # Preserve imports used by existing installations and third-party code.
 NetatmoCurrentTemperatureService = NetatmoRealtimeService
+
+
+def build_provider(config, *, metric=True, base_dir=None):
+    token_file = config.get("token_file", "netatmo-token.json")
+    if base_dir and not isabs(token_file):
+        token_file = str(Path(base_dir) / token_file)
+
+    return NetatmoRealtimeService(
+        client_id=_required(config, "client_id"),
+        client_secret=_required(config, "client_secret"),
+        refresh_token=_required(config, "refresh_token"),
+        token_file=token_file,
+        device_id=_optional(config, "device_id"),
+        module_id=_optional(config, "module_id"),
+        wind_module_id=_optional(config, "wind_module_id"),
+        rain_module_id=_optional(config, "rain_module_id"),
+        metric=metric,
+    )
+
+
+def _required(config, key):
+    value = config.get(key)
+    if value is None or value == "":
+        raise ProviderConfigurationError(
+            f"current_conditions.netatmo.{key} is required"
+        )
+    return value
+
+
+def _optional(config, key):
+    value = config.get(key)
+    return None if value == "" else value

--- a/server/weather/netatmo/netatmo.py
+++ b/server/weather/netatmo/netatmo.py
@@ -6,6 +6,7 @@ import time
 import requests
 
 from ..service import RealtimeProvider
+from ..models import CurrentConditions, Rain, Temperature, Wind
 
 
 class NetatmoRealtimeService(RealtimeProvider):
@@ -38,14 +39,14 @@ class NetatmoRealtimeService(RealtimeProvider):
         device = self._get_device(data)
         primary_source = self._measurement_source(device, self.module_id)
         dashboard_data = primary_source.get("dashboard_data", {})
-        conditions = {}
+        conditions = CurrentConditions()
 
         if "Temperature" in dashboard_data:
-            conditions["temperature"] = self._temperature(
+            conditions.temperature = self._temperature(
                 dashboard_data["Temperature"]
             )
         if "Humidity" in dashboard_data:
-            conditions["humidity"] = dashboard_data["Humidity"]
+            conditions.humidity = dashboard_data["Humidity"]
 
         wind_data = self._module_dashboard(
             device,
@@ -54,7 +55,7 @@ class NetatmoRealtimeService(RealtimeProvider):
             "WindStrength",
         )
         if wind_data:
-            conditions["wind"] = self._wind(wind_data)
+            conditions.wind = self._wind(wind_data)
 
         rain_data = self._module_dashboard(
             device,
@@ -63,9 +64,9 @@ class NetatmoRealtimeService(RealtimeProvider):
             "Rain",
         )
         if rain_data:
-            conditions["rain"] = self._rain(rain_data)
+            conditions.rain = self._rain(rain_data)
 
-        if not conditions:
+        if not conditions.to_dict():
             source_id = primary_source.get("_id", "unknown")
             raise ValueError(
                 f"No supported measurements found for Netatmo source {source_id}"
@@ -75,48 +76,52 @@ class NetatmoRealtimeService(RealtimeProvider):
 
     def get_current_temperature(self):
         conditions = self.get_current_conditions()
-        if "temperature" not in conditions:
+        if conditions.temperature is None:
             raise ValueError("No Temperature measurement found for Netatmo source")
-        return conditions["temperature"]
+        return conditions.temperature.to_dict()
 
     def _temperature(self, temperature_c):
         value = temperature_c if self.metric else (temperature_c * 9 / 5) + 32
-        return {
-            "source": "netatmo",
-            "live": True,
-            "unit": "\N{DEGREE SIGN}C" if self.metric else "\N{DEGREE SIGN}F",
-            "value": round(value),
-        }
+        return Temperature(
+            source="netatmo",
+            live=True,
+            unit="\N{DEGREE SIGN}C" if self.metric else "\N{DEGREE SIGN}F",
+            value=round(value),
+        )
 
     def _wind(self, data):
         factor = 1 if self.metric else 0.621371
-        wind = {
-            "source": "netatmo",
-            "live": True,
-            "unit": "kmh" if self.metric else "mph",
-            "value": round(data["WindStrength"] * factor, 1),
-        }
-        if "GustStrength" in data:
-            wind["gust"] = round(data["GustStrength"] * factor, 1)
-        if "WindAngle" in data:
-            wind["direction"] = data["WindAngle"]
-        return wind
+        return Wind(
+            source="netatmo",
+            live=True,
+            unit="kmh" if self.metric else "mph",
+            value=round(data["WindStrength"] * factor, 1),
+            gust=(
+                round(data["GustStrength"] * factor, 1)
+                if "GustStrength" in data
+                else None
+            ),
+            direction=data.get("WindAngle"),
+        )
 
     def _rain(self, data):
         factor = 1 if self.metric else 0.0393701
-        rain = {
-            "source": "netatmo",
-            "live": True,
-            "unit": "mm" if self.metric else "in",
-            "value": round(data["Rain"] * factor, 2),
-        }
-        for source_key, output_key in (
-            ("sum_rain_1", "last_hour"),
-            ("sum_rain_24", "last_24_hours"),
-        ):
-            if source_key in data:
-                rain[output_key] = round(data[source_key] * factor, 2)
-        return rain
+        return Rain(
+            source="netatmo",
+            live=True,
+            unit="mm" if self.metric else "in",
+            value=round(data["Rain"] * factor, 2),
+            last_hour=(
+                round(data["sum_rain_1"] * factor, 2)
+                if "sum_rain_1" in data
+                else None
+            ),
+            last_24_hours=(
+                round(data["sum_rain_24"] * factor, 2)
+                if "sum_rain_24" in data
+                else None
+            ),
+        )
 
     def _get_stations_data(self):
         token = self._get_access_token()

--- a/server/weather/netatmo/netatmo.py
+++ b/server/weather/netatmo/netatmo.py
@@ -1,5 +1,6 @@
 import json
 import os
+import tempfile
 import time
 
 import requests
@@ -126,27 +127,34 @@ class NetatmoRealtimeService(RealtimeProvider):
         )
 
         if response.status_code in [401, 403]:
-            token = self._refresh_access_token()
+            response.close()
+            token_data = self._load_token_data()
+            token = self._refresh_access_token(token_data.get("refresh_token"))
             response = requests.get(
                 f"{self.baseurl}/api/getstationsdata",
                 headers={"Authorization": f"Bearer {token}"},
                 timeout=20,
             )
 
-        if response.status_code != 200:
-            raise ValueError(
-                "Non-200 response from Netatmo api: {}".format(response.status_code)
-            )
-
-        data = response.json()
-        if data.get("status") and data["status"] != "ok":
-            raise ValueError(
-                "Unexpected response status from Netatmo api: {}".format(
-                    data["status"]
+        try:
+            if response.status_code != 200:
+                raise ValueError(
+                    "Non-200 response from Netatmo api: {}".format(
+                        response.status_code
+                    )
                 )
-            )
 
-        return data
+            data = response.json()
+            if data.get("status") and data["status"] != "ok":
+                raise ValueError(
+                    "Unexpected response status from Netatmo api: {}".format(
+                        data["status"]
+                    )
+                )
+
+            return data
+        finally:
+            response.close()
 
     def _get_device(self, data):
         body = data.get("body", {})
@@ -208,14 +216,19 @@ class NetatmoRealtimeService(RealtimeProvider):
             timeout=20,
         )
 
-        if response.status_code != 200:
-            raise ValueError(
-                "Non-200 response from Netatmo token api: {}".format(
-                    response.status_code
+        try:
+            if response.status_code != 200:
+                raise ValueError(
+                    "Non-200 response from Netatmo token api: {}".format(
+                        response.status_code
+                    )
                 )
-            )
 
-        token_data = response.json()
+            token_data = response.json()
+        finally:
+            response.close()
+
+        token_data.setdefault("refresh_token", token)
         token_data["expires_at"] = time.time() + token_data.get("expires_in", 0)
         self._save_token_data(token_data)
         return token_data["access_token"]
@@ -235,8 +248,25 @@ class NetatmoRealtimeService(RealtimeProvider):
         if token_dir:
             os.makedirs(token_dir, exist_ok=True)
 
-        with open(self.token_file, "w") as f:
-            json.dump(token_data, f)
+        directory = token_dir or "."
+        fd, temporary_path = tempfile.mkstemp(
+            dir=directory,
+            prefix=f".{os.path.basename(self.token_file)}.",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(token_data, f)
+                f.write("\n")
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(temporary_path, self.token_file)
+        except Exception:
+            try:
+                os.unlink(temporary_path)
+            except FileNotFoundError:
+                pass
+            raise
 
 
 # Preserve imports used by existing installations and third-party code.

--- a/server/weather/netatmo/netatmo.py
+++ b/server/weather/netatmo/netatmo.py
@@ -4,8 +4,10 @@ import time
 
 import requests
 
+from ..service import RealtimeProvider
 
-class NetatmoCurrentTemperatureService:
+
+class NetatmoRealtimeService(RealtimeProvider):
     def __init__(
         self,
         client_id,
@@ -14,6 +16,8 @@ class NetatmoCurrentTemperatureService:
         token_file,
         device_id=None,
         module_id=None,
+        wind_module_id=None,
+        rain_module_id=None,
         metric=True,
         baseurl="https://api.netatmo.com",
     ):
@@ -23,20 +27,95 @@ class NetatmoCurrentTemperatureService:
         self.token_file = token_file
         self.device_id = device_id
         self.module_id = module_id
+        self.wind_module_id = wind_module_id
+        self.rain_module_id = rain_module_id
         self.metric = metric
         self.baseurl = baseurl
 
-    def get_current_temperature(self):
+    def get_current_conditions(self):
         data = self._get_stations_data()
-        temperature_c = self._extract_temperature(data)
-        value = temperature_c if self.metric else (temperature_c * 9 / 5) + 32
+        device = self._get_device(data)
+        primary_source = self._measurement_source(device, self.module_id)
+        dashboard_data = primary_source.get("dashboard_data", {})
+        conditions = {}
 
+        if "Temperature" in dashboard_data:
+            conditions["temperature"] = self._temperature(
+                dashboard_data["Temperature"]
+            )
+        if "Humidity" in dashboard_data:
+            conditions["humidity"] = dashboard_data["Humidity"]
+
+        wind_data = self._module_dashboard(
+            device,
+            self.wind_module_id,
+            primary_source,
+            "WindStrength",
+        )
+        if wind_data:
+            conditions["wind"] = self._wind(wind_data)
+
+        rain_data = self._module_dashboard(
+            device,
+            self.rain_module_id,
+            primary_source,
+            "Rain",
+        )
+        if rain_data:
+            conditions["rain"] = self._rain(rain_data)
+
+        if not conditions:
+            source_id = primary_source.get("_id", "unknown")
+            raise ValueError(
+                f"No supported measurements found for Netatmo source {source_id}"
+            )
+
+        return conditions
+
+    def get_current_temperature(self):
+        conditions = self.get_current_conditions()
+        if "temperature" not in conditions:
+            raise ValueError("No Temperature measurement found for Netatmo source")
+        return conditions["temperature"]
+
+    def _temperature(self, temperature_c):
+        value = temperature_c if self.metric else (temperature_c * 9 / 5) + 32
         return {
             "source": "netatmo",
             "live": True,
             "unit": "\N{DEGREE SIGN}C" if self.metric else "\N{DEGREE SIGN}F",
             "value": round(value),
         }
+
+    def _wind(self, data):
+        factor = 1 if self.metric else 0.621371
+        wind = {
+            "source": "netatmo",
+            "live": True,
+            "unit": "kmh" if self.metric else "mph",
+            "value": round(data["WindStrength"] * factor, 1),
+        }
+        if "GustStrength" in data:
+            wind["gust"] = round(data["GustStrength"] * factor, 1)
+        if "WindAngle" in data:
+            wind["direction"] = data["WindAngle"]
+        return wind
+
+    def _rain(self, data):
+        factor = 1 if self.metric else 0.0393701
+        rain = {
+            "source": "netatmo",
+            "live": True,
+            "unit": "mm" if self.metric else "in",
+            "value": round(data["Rain"] * factor, 2),
+        }
+        for source_key, output_key in (
+            ("sum_rain_1", "last_hour"),
+            ("sum_rain_24", "last_24_hours"),
+        ):
+            if source_key in data:
+                rain[output_key] = round(data[source_key] * factor, 2)
+        return rain
 
     def _get_stations_data(self):
         token = self._get_access_token()
@@ -69,29 +148,32 @@ class NetatmoCurrentTemperatureService:
 
         return data
 
-    def _extract_temperature(self, data):
+    def _get_device(self, data):
         body = data.get("body", {})
         devices = body.get("devices", [])
         if len(devices) == 0:
             raise ValueError("No Netatmo weather stations found in response")
+        return self._find_by_id(devices, self.device_id, "station")
 
-        device = self._find_by_id(devices, self.device_id, "station")
-        measurement_source = device
+    def _measurement_source(self, device, module_id):
+        if not module_id:
+            return device
+        return self._find_by_id(device.get("modules", []), module_id, "module")
 
-        if self.module_id:
-            modules = device.get("modules", [])
-            measurement_source = self._find_by_id(modules, self.module_id, "module")
-
-        dashboard_data = measurement_source.get("dashboard_data", {})
-        if "Temperature" not in dashboard_data:
-            source_id = measurement_source.get("_id", "unknown")
-            raise ValueError(
-                "No Temperature measurement found for Netatmo source {}".format(
-                    source_id
-                )
-            )
-
-        return dashboard_data["Temperature"]
+    def _module_dashboard(
+        self,
+        device,
+        module_id,
+        fallback_source,
+        required_key,
+    ):
+        source = (
+            self._measurement_source(device, module_id)
+            if module_id
+            else fallback_source
+        )
+        dashboard = source.get("dashboard_data", {})
+        return dashboard if required_key in dashboard else None
 
     def _find_by_id(self, items, item_id, item_name):
         if item_id is None:
@@ -155,3 +237,7 @@ class NetatmoCurrentTemperatureService:
 
         with open(self.token_file, "w") as f:
             json.dump(token_data, f)
+
+
+# Preserve imports used by existing installations and third-party code.
+NetatmoCurrentTemperatureService = NetatmoRealtimeService

--- a/server/weather/openweathermapv3/openweathermapv3.py
+++ b/server/weather/openweathermapv3/openweathermapv3.py
@@ -1,7 +1,8 @@
 import requests
 import itertools
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from ..service import WeatherService
+from ..models import ForecastData
 
 
 class OpenWeatherMapv3Service(WeatherService):
@@ -15,26 +16,37 @@ class OpenWeatherMapv3Service(WeatherService):
         )
         self.lat, self.lon = self._get_location_coords(location)
 
-    def get_daily_summary(self):
-        data = None
+    def fetch(self):
         res = requests.get(
             self.baseurl
             + "/data/3.0/onecall?lat={}&lon={}&appid={}&units={}".format(
                 self.lat, self.lon, self.apikey, self.units
-            )
+            ),
+            timeout=20,
         )
-        if res.status_code != 200:
-            raise ValueError("Non-200 response from weather api: {}".format(res.history))
-                
-        data = res.json()
+        try:
+            if res.status_code != 200:
+                raise ValueError(
+                    "Non-200 response from weather api: {}".format(
+                        res.status_code
+                    )
+                )
+            data = res.json()
+        finally:
+            res.close()
 
+        return ForecastData.from_dicts(
+            self._daily_summary(data),
+            self._hourly_forecast(data),
+        ).validate()
+
+    def _daily_summary(self, data):
         if self.units == "metric":
             units = "\N{DEGREE SIGN}C"
         else:
             units = "\N{DEGREE SIGN}F"
 
         forecast = {
-            
             "icon": self.get_icon(data["current"]["weather"][0]["icon"]),
             "temperature": {
                 "unit": units,
@@ -44,23 +56,9 @@ class OpenWeatherMapv3Service(WeatherService):
             },
         }
 
-        res.close()
         return forecast
 
-    def get_hourly_forecast(self):
-        data = None
-        res = requests.get(
-            self.baseurl
-            + "/data/3.0/onecall?cnt={}&lat={}&lon={}&appid={}&units={}".format(
-                self.num_hours, self.lat, self.lon, self.apikey, self.units
-            )
-        )
-        
-        if res.status_code != 200:
-            raise ValueError("Non-200 response from weather api: {}".format(res.history))
-        
-        data = res.json()
-
+    def _hourly_forecast(self, data):
         if self.units == "metric":
             temp_units = "\N{DEGREE SIGN}C"
             speed_units = "m/s"
@@ -68,10 +66,21 @@ class OpenWeatherMapv3Service(WeatherService):
             temp_units = "\N{DEGREE SIGN}F"
             speed_units = "mph"
 
+        location_timezone = timezone(
+            timedelta(seconds=int(data.get("timezone_offset", 0)))
+        )
         forecasts = []
-        for entry in itertools.islice(data["hourly"],5 , self.num_hours*3, 3):
+        for entry in itertools.islice(
+            data["hourly"],
+            5,
+            5 + self.num_hours * 3,
+            3,
+        ):
             forecast = {
-                "dt": datetime.fromtimestamp(entry["dt"]),
+                "dt": datetime.fromtimestamp(
+                    entry["dt"],
+                    location_timezone,
+                ),
                 "icon": self.get_icon(entry["weather"][0]["icon"]),
                 "temperature": {
                     "unit": temp_units,
@@ -81,32 +90,48 @@ class OpenWeatherMapv3Service(WeatherService):
                     "unit": speed_units,
                     "value": entry["wind_speed"],
                 },
-                "humidity": (entry["humidity"]),
+                "humidity": entry["humidity"],
                 "rain_probability": round(entry["pop"] * 100),
             }
 
             forecasts.append(forecast)
-        res.close()
+        if len(forecasts) < self.num_hours:
+            raise ValueError(
+                "Unexpected response from weather api: "
+                f"needed {self.num_hours} forecast slots, "
+                f"received {len(forecasts)}"
+            )
         return forecasts
 
-    def _get_location_coords(self, location):
-        data = None
+    def get_daily_summary(self):
+        return self.fetch().current_dict()
 
+    def get_hourly_forecast(self):
+        return self.fetch().hourly_dicts()
+
+    def _get_location_coords(self, location):
         res = requests.get(
             self.baseurl
-            + "/geo/1.0/direct?q={}&limit=1&appid={}".format(location, self.apikey)
+            + "/geo/1.0/direct?q={}&limit=1&appid={}".format(
+                location,
+                self.apikey,
+            ),
+            timeout=20,
         )
-        data = res.json()
+        try:
+            if res.status_code != 200:
+                raise ValueError(
+                    "Non-200 response from weather api: {}".format(
+                        res.status_code
+                    )
+                )
+            data = res.json()
+        finally:
+            res.close()
 
-        if res.status_code != 200:
-            raise ValueError("Non-200 response from weather api: {}".format(res.history))
+        if len(data) != 1:
+            raise ValueError(
+                "Unexpected response from weather api: {}".format(data)
+            )
 
-        if len(data) == 0 or len(data) > 1:
-            raise ValueError("Unexpected response from weather api: {}".format(data))
-
-        data = data[0]
-        lat = data["lat"]
-        lon = data["lon"]
-
-        res.close()
-        return lat, lon
+        return data[0]["lat"], data[0]["lon"]

--- a/server/weather/openweathermapv3/openweathermapv3.py
+++ b/server/weather/openweathermapv3/openweathermapv3.py
@@ -31,7 +31,7 @@ class OpenWeatherMapv3Service(WeatherService):
         if self.units == "metric":
             units = "\N{DEGREE SIGN}C"
         else:
-            units = ("\N{DEGREE SIGN}F",)
+            units = "\N{DEGREE SIGN}F"
 
         forecast = {
             
@@ -63,7 +63,7 @@ class OpenWeatherMapv3Service(WeatherService):
 
         if self.units == "metric":
             temp_units = "\N{DEGREE SIGN}C"
-            speed_units = "kmh"
+            speed_units = "m/s"
         else:
             temp_units = "\N{DEGREE SIGN}F"
             speed_units = "mph"
@@ -79,7 +79,7 @@ class OpenWeatherMapv3Service(WeatherService):
                 },
                 "wind": {
                     "unit": speed_units,
-                    "real": (entry["wind_speed"]),
+                    "value": entry["wind_speed"],
                 },
                 "humidity": (entry["humidity"]),
                 "rain_probability": round(entry["pop"] * 100),

--- a/server/weather/openweathermapv3/openweathermapv3.py
+++ b/server/weather/openweathermapv3/openweathermapv3.py
@@ -135,3 +135,12 @@ class OpenWeatherMapv3Service(WeatherService):
             )
 
         return data[0]["lat"], data[0]["lon"]
+
+
+def build_provider(config):
+    return OpenWeatherMapv3Service(
+        apikey=config["apikey"],
+        location=config["location"],
+        metric=config.get("metric", True),
+        num_hours=config.get("num_hours", 6),
+    )

--- a/server/weather/openweathermapv4/openweathermapv4.py
+++ b/server/weather/openweathermapv4/openweathermapv4.py
@@ -187,3 +187,12 @@ class OpenWeatherMapv4Service(WeatherService):
         if self.units == "metric":
             return celsius
         return celsius * 9 / 5 + 32
+
+
+def build_provider(config):
+    return OpenWeatherMapv4Service(
+        apikey=config["apikey"],
+        location=config["location"],
+        metric=config.get("metric", True),
+        num_hours=config.get("num_hours", 6),
+    )

--- a/server/weather/openweathermapv4/openweathermapv4.py
+++ b/server/weather/openweathermapv4/openweathermapv4.py
@@ -4,6 +4,7 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 import requests
 
 from ..service import WeatherService
+from ..models import ForecastData
 
 
 class OpenWeatherMapv4Service(WeatherService):
@@ -44,6 +45,12 @@ class OpenWeatherMapv4Service(WeatherService):
                 "max": round(self._temperature_value(daily["temp"]["max"])),
             },
         }
+
+    def fetch(self):
+        return ForecastData.from_dicts(
+            self.get_daily_summary(),
+            self.get_hourly_forecast(),
+        ).validate()
 
     def get_hourly_forecast(self):
         required_records = self.HOURLY_STEP * self.num_hours + 3

--- a/server/weather/openweathermapv4/openweathermapv4.py
+++ b/server/weather/openweathermapv4/openweathermapv4.py
@@ -82,7 +82,7 @@ class OpenWeatherMapv4Service(WeatherService):
                 },
                 "wind": {
                     "unit": "m/s" if self.units == "metric" else "mph",
-                    "real": entry["wind_speed"],
+                    "value": entry["wind_speed"],
                 },
                 "humidity": entry["humidity"],
                 "rain_probability": round(entry.get("pop", 0) * 100),

--- a/server/weather/providers.py
+++ b/server/weather/providers.py
@@ -1,42 +1,37 @@
 from dataclasses import dataclass
 from importlib import import_module
-from os.path import isabs
-from pathlib import Path
+
+from .service import ProviderConfigurationError
 
 
-class ConfigurationError(ValueError):
-    pass
+ConfigurationError = ProviderConfigurationError
 
 
 @dataclass(frozen=True)
 class ProviderDefinition:
     module: str
-    class_name: str
+    builder_name: str = "build_provider"
 
-    def build(self, **kwargs):
-        provider_class = getattr(import_module(self.module), self.class_name)
-        return provider_class(**kwargs)
+    def build(self, config, **context):
+        builder = getattr(import_module(self.module), self.builder_name)
+        return builder(config, **context)
 
 
 FORECAST_PROVIDERS = {
     "accuweather": ProviderDefinition(
         "weather.accuweather.accuweather",
-        "AccuweatherService",
     ),
     "openweathermapv3": ProviderDefinition(
         "weather.openweathermapv3.openweathermapv3",
-        "OpenWeatherMapv3Service",
     ),
     "openweathermapv4": ProviderDefinition(
         "weather.openweathermapv4.openweathermapv4",
-        "OpenWeatherMapv4Service",
     ),
 }
 
 REALTIME_PROVIDERS = {
     "netatmo": ProviderDefinition(
         "weather.netatmo.netatmo",
-        "NetatmoRealtimeService",
     ),
 }
 
@@ -70,10 +65,12 @@ def build_forecast_provider(
         )
 
     return definition.build(
-        apikey=apikey,
-        location=location,
-        metric=metric,
-        num_hours=num_hours,
+        {
+            "apikey": apikey,
+            "location": location,
+            "metric": metric,
+            "num_hours": num_hours,
+        }
     )
 
 
@@ -94,39 +91,14 @@ def build_realtime_provider(config, *, metric=True, base_dir=None):
         )
 
     provider_config = realtime_config.get(name, realtime_config)
-    kwargs = {
-        "client_id": _required(provider_config, name, "client_id"),
-        "client_secret": _required(provider_config, name, "client_secret"),
-        "refresh_token": _required(provider_config, name, "refresh_token"),
-        "token_file": provider_config.get("token_file", "netatmo-token.json"),
-        "device_id": _optional(provider_config, "device_id"),
-        "module_id": _optional(provider_config, "module_id"),
-        "wind_module_id": _optional(provider_config, "wind_module_id"),
-        "rain_module_id": _optional(provider_config, "rain_module_id"),
-        "metric": metric,
-    }
-
-    if base_dir and not isabs(kwargs["token_file"]):
-        kwargs["token_file"] = str(Path(base_dir) / kwargs["token_file"])
-
-    return definition.build(**kwargs)
+    return definition.build(
+        provider_config,
+        metric=metric,
+        base_dir=base_dir,
+    )
 
 
 def _provider_name(value, key):
     if value is None or str(value).strip() == "":
         raise ConfigurationError(f"{key} is required")
     return str(value).strip().lower()
-
-
-def _required(config, provider, key):
-    value = config.get(key)
-    if value is None or value == "":
-        raise ConfigurationError(
-            f"current_conditions.{provider}.{key} is required"
-        )
-    return value
-
-
-def _optional(config, key):
-    value = config.get(key)
-    return None if value == "" else value

--- a/server/weather/providers.py
+++ b/server/weather/providers.py
@@ -1,0 +1,132 @@
+from dataclasses import dataclass
+from importlib import import_module
+from os.path import isabs
+from pathlib import Path
+
+
+class ConfigurationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ProviderDefinition:
+    module: str
+    class_name: str
+
+    def build(self, **kwargs):
+        provider_class = getattr(import_module(self.module), self.class_name)
+        return provider_class(**kwargs)
+
+
+FORECAST_PROVIDERS = {
+    "accuweather": ProviderDefinition(
+        "weather.accuweather.accuweather",
+        "AccuweatherService",
+    ),
+    "openweathermapv3": ProviderDefinition(
+        "weather.openweathermapv3.openweathermapv3",
+        "OpenWeatherMapv3Service",
+    ),
+    "openweathermapv4": ProviderDefinition(
+        "weather.openweathermapv4.openweathermapv4",
+        "OpenWeatherMapv4Service",
+    ),
+}
+
+REALTIME_PROVIDERS = {
+    "netatmo": ProviderDefinition(
+        "weather.netatmo.netatmo",
+        "NetatmoRealtimeService",
+    ),
+}
+
+REMOVED_FORECAST_PROVIDERS = {
+    "openweathermap": (
+        "weather.service openweathermap was removed; "
+        "use openweathermapv3 or openweathermapv4"
+    ),
+}
+
+
+def build_forecast_provider(
+    provider_name,
+    *,
+    apikey,
+    location,
+    metric=True,
+    num_hours=6,
+):
+    name = _provider_name(provider_name, "weather.service")
+    if name in REMOVED_FORECAST_PROVIDERS:
+        raise ConfigurationError(REMOVED_FORECAST_PROVIDERS[name])
+
+    definition = FORECAST_PROVIDERS.get(name)
+    if definition is None:
+        raise ConfigurationError(
+            "unsupported weather.service {}; supported providers: {}".format(
+                name,
+                ", ".join(sorted(FORECAST_PROVIDERS)),
+            )
+        )
+
+    return definition.build(
+        apikey=apikey,
+        location=location,
+        metric=metric,
+        num_hours=num_hours,
+    )
+
+
+def build_realtime_provider(config, *, metric=True, base_dir=None):
+    realtime_config = config or {}
+    name = _provider_name(
+        realtime_config.get("source", "weather"),
+        "current_conditions.source",
+    )
+    if name == "weather":
+        return None
+
+    definition = REALTIME_PROVIDERS.get(name)
+    if definition is None:
+        raise ConfigurationError(
+            "unsupported current_conditions.source {}; supported providers: "
+            "weather, {}".format(name, ", ".join(sorted(REALTIME_PROVIDERS)))
+        )
+
+    provider_config = realtime_config.get(name, realtime_config)
+    kwargs = {
+        "client_id": _required(provider_config, name, "client_id"),
+        "client_secret": _required(provider_config, name, "client_secret"),
+        "refresh_token": _required(provider_config, name, "refresh_token"),
+        "token_file": provider_config.get("token_file", "netatmo-token.json"),
+        "device_id": _optional(provider_config, "device_id"),
+        "module_id": _optional(provider_config, "module_id"),
+        "wind_module_id": _optional(provider_config, "wind_module_id"),
+        "rain_module_id": _optional(provider_config, "rain_module_id"),
+        "metric": metric,
+    }
+
+    if base_dir and not isabs(kwargs["token_file"]):
+        kwargs["token_file"] = str(Path(base_dir) / kwargs["token_file"])
+
+    return definition.build(**kwargs)
+
+
+def _provider_name(value, key):
+    if value is None or str(value).strip() == "":
+        raise ConfigurationError(f"{key} is required")
+    return str(value).strip().lower()
+
+
+def _required(config, provider, key):
+    value = config.get(key)
+    if value is None or value == "":
+        raise ConfigurationError(
+            f"current_conditions.{provider}.{key} is required"
+        )
+    return value
+
+
+def _optional(config, key):
+    value = config.get(key)
+    return None if value == "" else value

--- a/server/weather/service.py
+++ b/server/weather/service.py
@@ -1,8 +1,9 @@
 import os
 import json
+from abc import ABC, abstractmethod
 
 
-class WeatherService:
+class ForecastProvider(ABC):
     def __init__(
         self, apikey, baseurl, service_name, num_hours=6, metric=True
     ):
@@ -29,8 +30,20 @@ class WeatherService:
 
         return f"icon/{icon_map[icon_key]}"
 
+    @abstractmethod
     def get_daily_summary(self):
-        raise NotImplementedError("get_current_conditions not implemented")
+        """Return normalized current conditions and today's forecast."""
 
+    @abstractmethod
     def get_hourly_forecast(self):
-        raise NotImplementedError("get_forecast not implemented")
+        """Return normalized hourly forecast records."""
+
+
+class RealtimeProvider(ABC):
+    @abstractmethod
+    def get_current_conditions(self):
+        """Return a partial normalized current-conditions overlay."""
+
+
+# Backwards-compatible name for existing forecast provider implementations.
+WeatherService = ForecastProvider

--- a/server/weather/service.py
+++ b/server/weather/service.py
@@ -2,6 +2,8 @@ import os
 import json
 from abc import ABC, abstractmethod
 
+from .models import CurrentConditions, ForecastData
+
 
 class ForecastProvider(ABC):
     def __init__(
@@ -31,17 +33,13 @@ class ForecastProvider(ABC):
         return f"icon/{icon_map[icon_key]}"
 
     @abstractmethod
-    def get_daily_summary(self):
-        """Return normalized current conditions and today's forecast."""
-
-    @abstractmethod
-    def get_hourly_forecast(self):
-        """Return normalized hourly forecast records."""
+    def fetch(self) -> ForecastData:
+        """Return a complete normalized forecast."""
 
 
 class RealtimeProvider(ABC):
     @abstractmethod
-    def get_current_conditions(self):
+    def get_current_conditions(self) -> CurrentConditions:
         """Return a partial normalized current-conditions overlay."""
 
 

--- a/server/weather/service.py
+++ b/server/weather/service.py
@@ -5,6 +5,10 @@ from abc import ABC, abstractmethod
 from .models import CurrentConditions, ForecastData
 
 
+class ProviderConfigurationError(ValueError):
+    pass
+
+
 class ForecastProvider(ABC):
     def __init__(
         self, apikey, baseurl, service_name, num_hours=6, metric=True

--- a/server/weather/snapshot.py
+++ b/server/weather/snapshot.py
@@ -2,6 +2,9 @@ import copy
 import datetime as dt
 
 
+SCHEMA_VERSION = "2.0"
+
+
 class WeatherSnapshot:
     def __init__(
         self,
@@ -19,7 +22,7 @@ class WeatherSnapshot:
 
     def to_payload(self):
         return {
-            "schema_version": "1.0",
+            "schema_version": SCHEMA_VERSION,
             "generated_at": self.generated_at.isoformat(),
             "source": self.weather_source,
             "units": "metric" if self.metric else "imperial",

--- a/server/weather/snapshot.py
+++ b/server/weather/snapshot.py
@@ -1,6 +1,8 @@
 import copy
 import datetime as dt
 
+from .models import ForecastData
+
 
 SCHEMA_VERSION = "2.0"
 
@@ -13,9 +15,12 @@ class WeatherSnapshot:
         weather_source,
         metric=True,
         generated_at=None,
+        forecast=None,
     ):
-        self.daily_summary = daily_summary
-        self.hourly_forecasts = hourly_forecasts
+        self.forecast = forecast or ForecastData.from_dicts(
+            daily_summary,
+            hourly_forecasts,
+        )
         self.weather_source = weather_source
         self.metric = metric
         self.generated_at = generated_at or dt.datetime.now(dt.timezone.utc)
@@ -29,6 +34,14 @@ class WeatherSnapshot:
             "current": _serializable(self.daily_summary),
             "hourly": _serializable(self.hourly_forecasts),
         }
+
+    @property
+    def daily_summary(self):
+        return self.forecast.current_dict()
+
+    @property
+    def hourly_forecasts(self):
+        return self.forecast.hourly_dicts()
 
 
 def _serializable(value):

--- a/server/web.py
+++ b/server/web.py
@@ -100,6 +100,35 @@ def register_routes(app):
             as_attachment=False,
         )
 
+    @app.get("/api/v1/outputs/<profile_name>/status")
+    def output_status(profile_name):
+        profile = _profiles(app).get(profile_name)
+        if profile is None:
+            abort(404)
+
+        store = _store(app)
+        if not store.output_status({profile_name: profile})[profile_name]:
+            return jsonify({"error": "output is not available"}), 503
+
+        try:
+            with store.ready_path.open(encoding="utf-8") as ready_file:
+                ready = json.load(ready_file)
+            output = ready["outputs"][profile_name]
+            sha256 = output["sha256"]
+            generated_at = ready["generated_at"]
+        except (KeyError, OSError, TypeError, json.JSONDecodeError):
+            return jsonify({"error": "output is not available"}), 503
+
+        return jsonify(
+            {
+                "profile": profile.name,
+                "filename": profile.filename,
+                "url": f"/outputs/{profile.name}/{profile.filename}",
+                "generated_at": generated_at,
+                "sha256": sha256,
+            }
+        )
+
     @app.get("/calendar.png")
     def legacy_calendar_output():
         response = _send_default_output(app, as_attachment=True)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,0 +1,174 @@
+#include <ArduinoYaml.h>
+#include <StreamUtils.h>
+
+#include "config.h"
+#include "lib.h"
+
+#if defined(EMBEDDED_CONFIG)
+#include "embedded_config.h"
+#endif
+
+namespace
+{
+bool isMissingConfigValue(const char *value)
+{
+    return value == nullptr || value[0] == '\0';
+}
+
+bool failConfig(const char *message)
+{
+    log(LOG_ERROR, message);
+    displayError(
+        "Config error",
+        message,
+        configDiagnostics(CONFIG_SOURCE));
+    sleep(CONFIG_DEFAULT_CALENDAR_DAILY_REFRESH_INTERVAL);
+    return false;
+}
+
+bool failConfigLoad(const DeserializationError &error)
+{
+    const char *message = "Failed to load configuration";
+    logf(LOG_ERROR, "failed to deserialize YAML: %s", error.c_str());
+    String diagnostics = configDiagnostics(CONFIG_SOURCE);
+    diagnostics = appendDiagnostic(diagnostics, "Parser: ", error.c_str());
+    displayError("Config error", message, diagnostics);
+    sleep(CONFIG_DEFAULT_CALENDAR_DAILY_REFRESH_INTERVAL);
+    return false;
+}
+
+DeserializationError loadConfigurationDocument(
+    StaticJsonDocument<CONFIG_YAML_DOCUMENT_CAPACITY> &document)
+{
+#if defined(EMBEDDED_CONFIG)
+    return deserializeYml(document, EMBEDDED_CONFIG_YAML);
+#else
+    if (!board.sdCardInit())
+    {
+        const char *message = "SD card init failure";
+        log(LOG_ERROR, message);
+        displayError("Storage error", message);
+        sleep(CONFIG_DEFAULT_CALENDAR_DAILY_REFRESH_INTERVAL);
+    }
+
+    SdFat &sd = board.getSdFat();
+    File file = sd.open(CONFIG_FILE_PATH, FILE_READ);
+    if (!file)
+    {
+        const char *message = "Failed to open config file";
+        log(LOG_ERROR, message);
+        displayError(
+            "Config error",
+            message,
+            configDiagnostics(CONFIG_FILE_PATH));
+        sleep(CONFIG_DEFAULT_CALENDAR_DAILY_REFRESH_INTERVAL);
+    }
+
+    ReadBufferingStream bufferedFile(file, CONFIG_SD_READ_BUFFER_SIZE);
+    DeserializationError error = deserializeYml(document, bufferedFile);
+
+    // Keep the explicit ordering: parsing completes, the file closes, and only
+    // then is the SD card put back to sleep.
+    file.close();
+    board.sdCardSleep();
+    return error;
+#endif
+}
+} // namespace
+
+bool loadRuntimeConfig(
+    StaticJsonDocument<CONFIG_YAML_DOCUMENT_CAPACITY> &document,
+    RuntimeConfig &config)
+{
+    DeserializationError error = loadConfigurationDocument(document);
+    if (error)
+    {
+        return failConfigLoad(error);
+    }
+
+    JsonObject display = document["display"];
+    config.displayRotation =
+        display["rotation"] | CONFIG_DEFAULT_DISPLAY_ROTATION;
+    if (config.displayRotation < 0 || config.displayRotation > 3)
+    {
+        return failConfig("Invalid display.rotation");
+    }
+
+    JsonObject calendar = document["calendar"];
+    config.calendarUrl = calendar["url"];
+    config.calendarRetries = calendar["retries"] | 3;
+    config.calendarRefreshInterval =
+        calendar["refresh_interval"] |
+        CONFIG_DEFAULT_CALENDAR_DAILY_REFRESH_INTERVAL;
+
+    JsonObject wifi = document["wifi"];
+    config.wifiSSID = wifi["ssid"];
+    config.wifiPass = wifi["pass"] | "";
+    config.wifiRetries = wifi["retries"] | 6;
+
+    config.ntpHost = document["ntp"]["host"];
+    config.ntpTimezone = document["ntp"]["timezone"];
+
+    JsonObject mqtt = document["mqtt_logger"];
+    config.mqttLoggerEnabled = mqtt["enabled"] | false;
+    config.mqttDebugEnabled = mqtt["debug"] | false;
+    config.mqttLoggerBroker = mqtt["broker"];
+    config.mqttLoggerPort = mqtt["port"] | 1883;
+    config.mqttLoggerClientID = mqtt["clientId"];
+    config.mqttLoggerTopic = mqtt["topic"];
+    config.mqttLoggerRetries = mqtt["retries"] | 3;
+
+    if (isMissingConfigValue(config.calendarUrl))
+    {
+        return failConfig("Missing calendar.url");
+    }
+    if (config.calendarRefreshInterval <= 0)
+    {
+        return failConfig("Invalid calendar.refresh_interval");
+    }
+    if (config.calendarRetries < 0)
+    {
+        return failConfig("Invalid calendar.retries");
+    }
+    if (isMissingConfigValue(config.wifiSSID))
+    {
+        return failConfig("Missing wifi.ssid");
+    }
+    if (config.wifiRetries < 0)
+    {
+        return failConfig("Invalid wifi.retries");
+    }
+    if (isMissingConfigValue(config.ntpHost))
+    {
+        return failConfig("Missing ntp.host");
+    }
+    if (isMissingConfigValue(config.ntpTimezone))
+    {
+        return failConfig("Missing ntp.timezone");
+    }
+    if (config.mqttLoggerEnabled)
+    {
+        if (isMissingConfigValue(config.mqttLoggerBroker))
+        {
+            return failConfig("Missing mqtt_logger.broker");
+        }
+        if (config.mqttLoggerPort <= 0)
+        {
+            return failConfig("Invalid mqtt_logger.port");
+        }
+        if (isMissingConfigValue(config.mqttLoggerClientID))
+        {
+            return failConfig("Missing mqtt_logger.clientId");
+        }
+        if (isMissingConfigValue(config.mqttLoggerTopic))
+        {
+            return failConfig("Missing mqtt_logger.topic");
+        }
+        if (config.mqttLoggerRetries < 0)
+        {
+            return failConfig("Invalid mqtt_logger.retries");
+        }
+    }
+
+    return true;
+}

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -101,6 +101,8 @@ bool loadRuntimeConfig(
     config.calendarRefreshInterval =
         calendar["refresh_interval"] |
         CONFIG_DEFAULT_CALENDAR_DAILY_REFRESH_INTERVAL;
+    config.calendarRetryIntervalMinutes =
+        calendar["retry_interval_minutes"] | 15;
 
     JsonObject wifi = document["wifi"];
     config.wifiSSID = wifi["ssid"];
@@ -130,6 +132,10 @@ bool loadRuntimeConfig(
     if (config.calendarRetries < 0)
     {
         return failConfig("Invalid calendar.retries");
+    }
+    if (config.calendarRetryIntervalMinutes <= 0)
+    {
+        return failConfig("Invalid calendar.retry_interval_minutes");
     }
     if (isMissingConfigValue(config.wifiSSID))
     {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -96,6 +96,7 @@ bool loadRuntimeConfig(
 
     JsonObject calendar = document["calendar"];
     config.calendarUrl = calendar["url"];
+    config.calendarStatusUrl = calendar["status_url"] | "";
     config.calendarRetries = calendar["retries"] | 3;
     config.calendarRefreshInterval =
         calendar["refresh_interval"] |

--- a/src/config.h
+++ b/src/config.h
@@ -5,7 +5,7 @@
 
 // Sized for the documented configuration fields plus moderate MQTT and URL
 // growth. Review this capacity whenever fields are added to RuntimeConfig.
-constexpr size_t CONFIG_YAML_DOCUMENT_CAPACITY = 768;
+constexpr size_t CONFIG_YAML_DOCUMENT_CAPACITY = 896;
 // SD configuration is parsed through a small fixed buffer to avoid byte-at-a-
 // time reads without retaining a large buffer while the radio is active.
 constexpr size_t CONFIG_SD_READ_BUFFER_SIZE = 64;
@@ -14,6 +14,7 @@ struct RuntimeConfig
 {
     int displayRotation;
     const char *calendarUrl;
+    const char *calendarStatusUrl;
     int calendarRetries;
     int calendarRefreshInterval;
     const char *wifiSSID;

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,37 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include <ArduinoJson.h>
+
+// Sized for the documented configuration fields plus moderate MQTT and URL
+// growth. Review this capacity whenever fields are added to RuntimeConfig.
+constexpr size_t CONFIG_YAML_DOCUMENT_CAPACITY = 768;
+// SD configuration is parsed through a small fixed buffer to avoid byte-at-a-
+// time reads without retaining a large buffer while the radio is active.
+constexpr size_t CONFIG_SD_READ_BUFFER_SIZE = 64;
+
+struct RuntimeConfig
+{
+    int displayRotation;
+    const char *calendarUrl;
+    int calendarRetries;
+    int calendarRefreshInterval;
+    const char *wifiSSID;
+    const char *wifiPass;
+    int wifiRetries;
+    const char *ntpHost;
+    const char *ntpTimezone;
+    bool mqttLoggerEnabled;
+    bool mqttDebugEnabled;
+    const char *mqttLoggerBroker;
+    int mqttLoggerPort;
+    const char *mqttLoggerClientID;
+    const char *mqttLoggerTopic;
+    int mqttLoggerRetries;
+};
+
+bool loadRuntimeConfig(
+    StaticJsonDocument<CONFIG_YAML_DOCUMENT_CAPACITY> &document,
+    RuntimeConfig &config);
+
+#endif

--- a/src/config.h
+++ b/src/config.h
@@ -17,6 +17,7 @@ struct RuntimeConfig
     const char *calendarStatusUrl;
     int calendarRetries;
     int calendarRefreshInterval;
+    int calendarRetryIntervalMinutes;
     const char *wifiSSID;
     const char *wifiPass;
     int wifiRetries;

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -36,10 +36,13 @@ namespace
 constexpr time_t NTP_RESYNC_INTERVAL_SECONDS = 24 * 60 * 60;
 constexpr time_t MIN_VALID_RTC_EPOCH = 1577836800; // 2020-01-01T00:00:00Z
 
-uint32_t errorSignature(const char *title, const char *detail)
+uint32_t errorSignature(
+    const char *title,
+    const char *detail,
+    const String &diagnostics)
 {
     uint32_t hash = 2166136261UL;
-    const char *values[] = {title, detail};
+    const char *values[] = {title, detail, diagnostics.c_str()};
     for (const char *value : values)
     {
         if (value != nullptr)
@@ -262,7 +265,7 @@ esp_err_t fetchCalendarSignature(
 */
 void displayError(const char *title, const char *detail, const String &diagnostics)
 {
-    const uint32_t signature = errorSignature(title, detail);
+    const uint32_t signature = errorSignature(title, detail, diagnostics);
     if (displayedErrorSignature == signature)
     {
         log(LOG_INFO, "error screen unchanged; skipping display refresh");
@@ -635,13 +638,14 @@ void shutdownNetwork()
 }
 
 /**
-  Connect to an NTP server and synchronize the on-board real-time clock.
+  Configure timezone rules and synchronize the on-board real-time clock from
+  NTP when synchronization is due.
 
   @param host the hostname of the NTP server (eg. pool.ntp.org).
   @param timezoneName the name of the timezone in Olson format (eg.
   Europe/Dublin)
   @returns the esp_err_t code:
-  - ESP_OK if successful.
+  - ESP_OK if the retained RTC is valid or synchronization succeeds.
   - ESP_ERR_ENTP if updating the NTP client fails.
 */
 esp_err_t configureTime(const char *ntpHost, const char *timezoneName)

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -712,12 +712,25 @@ void sleep(const int sleepHours)
     {
         boundedSleepHours = CONFIG_DEFAULT_CALENDAR_DAILY_REFRESH_INTERVAL;
     }
+    sleepForSeconds(
+        static_cast<uint32_t>(boundedSleepHours) * 60UL * 60UL);
+}
+
+void sleepForSeconds(const uint32_t sleepSeconds)
+{
+    uint32_t boundedSleepSeconds = sleepSeconds;
+    if (boundedSleepSeconds == 0)
+    {
+        boundedSleepSeconds =
+            CONFIG_DEFAULT_CALENDAR_DAILY_REFRESH_INTERVAL * 60UL * 60UL;
+    }
 
     log(LOG_NOTICE, "deep sleep initiated");
     time_t rtcTime = board.rtc.getEpoch();
     logf(LOG_DEBUG, "RTC time now is %s", dateTime(rtcTime, RFC3339).c_str());
 
-    logf(LOG_INFO, "waking in %d hours", boundedSleepHours);
+    logf(LOG_INFO, "waking in %lu seconds",
+         static_cast<unsigned long>(boundedSleepSeconds));
     lastSleepTime = rtcTime;
 
     log(LOG_NOTICE, "Shutdown is NOW!");
@@ -728,7 +741,8 @@ void sleep(const int sleepHours)
     board.sdCardSleep();
 #endif
 
-    const uint64_t sleepMicroseconds = ((uint64_t)boundedSleepHours * 60 * 60 * 1000 * 1000); // Convert the Hours interval into microseconds
+    const uint64_t sleepMicroseconds =
+        static_cast<uint64_t>(boundedSleepSeconds) * 1000ULL * 1000ULL;
     logf(LOG_DEBUG, "Enable sleep timer for wakeup after %llu microseconds", sleepMicroseconds);
     esp_sleep_enable_timer_wakeup(sleepMicroseconds);
     log(LOG_NOTICE, "Sleeping...");

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -6,9 +6,13 @@ RTC_DATA_ATTR time_t lastBootTime = 0;
 RTC_DATA_ATTR time_t lastSleepTime = 0;
 // Avoid redrawing the same retained low-battery screen on every wake.
 RTC_DATA_ATTR bool batteryLowWarningDisplayed = false;
+// Avoid driving the panel repeatedly for the same retained error screen.
+RTC_DATA_ATTR uint32_t displayedErrorSignature = 0;
 // Cache timezone rules across deep sleep to avoid a network lookup every wake.
 RTC_DATA_ATTR char cachedTimezoneName[64] = "";
 RTC_DATA_ATTR char cachedTimezonePosix[96] = "";
+// RTC epoch of the last successful NTP synchronization.
+RTC_DATA_ATTR time_t lastNtpSyncTime = 0;
 
 // Remote MQTT diagnostics.
 esp_mqtt_client_handle_t mqttClient = nullptr;
@@ -21,6 +25,32 @@ const char *mqttLogTopic = nullptr;
 Inkplate board(INKPLATE_3BIT);
 // timezone store
 Timezone myTz;
+
+namespace
+{
+constexpr time_t NTP_RESYNC_INTERVAL_SECONDS = 24 * 60 * 60;
+constexpr time_t MIN_VALID_RTC_EPOCH = 1577836800; // 2020-01-01T00:00:00Z
+
+uint32_t errorSignature(const char *title, const char *detail)
+{
+    uint32_t hash = 2166136261UL;
+    const char *values[] = {title, detail};
+    for (const char *value : values)
+    {
+        if (value != nullptr)
+        {
+            while (*value != '\0')
+            {
+                hash ^= static_cast<uint8_t>(*value++);
+                hash *= 16777619UL;
+            }
+        }
+        hash ^= 0xFF;
+        hash *= 16777619UL;
+    }
+    return hash;
+}
+} // namespace
 
 esp_err_t handleMQTTEvent(esp_mqtt_event_handle_t event)
 {
@@ -161,6 +191,7 @@ esp_err_t displayImage(const char *url)
     log(LOG_DEBUG, "shutting down network before display refresh");
     shutdownNetwork();
     board.display();
+    displayedErrorSignature = 0;
 
     return ESP_OK;
 }
@@ -175,6 +206,13 @@ esp_err_t displayImage(const char *url)
 */
 void displayError(const char *title, const char *detail, const String &diagnostics)
 {
+    const uint32_t signature = errorSignature(title, detail);
+    if (displayedErrorSignature == signature)
+    {
+        log(LOG_INFO, "error screen unchanged; skipping display refresh");
+        return;
+    }
+
     const uint8_t black = 0;
     const uint8_t white = 7;
     const int margin = 24;
@@ -206,6 +244,7 @@ void displayError(const char *title, const char *detail, const String &diagnosti
     }
 
     board.display();
+    displayedErrorSignature = signature;
 }
 
 void displayError(const char *title, const char *detail)
@@ -553,13 +592,6 @@ esp_err_t configureTime(const char *ntpHost, const char *timezoneName)
 {
     log(LOG_INFO, "configuring network time and RTC...");
 
-    setServer(ntpHost);
-    updateNTP();
-    if (!waitForSync(5))
-    {
-        return ESP_ERR_ENTP;
-    }
-
     if (strcmp(cachedTimezoneName, timezoneName) == 0 &&
         cachedTimezonePosix[0] != '\0')
     {
@@ -579,9 +611,33 @@ esp_err_t configureTime(const char *ntpHost, const char *timezoneName)
                                   sizeof(cachedTimezonePosix));
     }
 
+    const time_t rtcTime = board.rtc.getEpoch();
+    const bool rtcInvalid = rtcTime < MIN_VALID_RTC_EPOCH;
+    const bool rtcMovedBackwards =
+        lastNtpSyncTime > 0 && rtcTime < lastNtpSyncTime;
+    const bool syncDue =
+        lastNtpSyncTime == 0 ||
+        rtcInvalid ||
+        rtcMovedBackwards ||
+        rtcTime - lastNtpSyncTime >= NTP_RESYNC_INTERVAL_SECONDS;
+    if (!syncDue)
+    {
+        logf(LOG_INFO, "using RTC time; last NTP sync was %lld seconds ago",
+             static_cast<long long>(rtcTime - lastNtpSyncTime));
+        return ESP_OK;
+    }
+
+    setServer(ntpHost);
+    updateNTP();
+    if (!waitForSync(5))
+    {
+        return ESP_ERR_ENTP;
+    }
+
     // Sync RTC with NTP time
     time_t nowTime = myTz.now();
     board.rtc.setEpoch(nowTime);
+    lastNtpSyncTime = nowTime;
     logf(LOG_INFO, "RTC synced to %s", dateTime(nowTime, RFC3339).c_str());
 
     return ESP_OK;

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -1,3 +1,6 @@
+#include <ArduinoJson.h>
+#include <ctype.h>
+
 #include "lib.h"
 
 // RTC epoch of the last time we booted.
@@ -13,6 +16,8 @@ RTC_DATA_ATTR char cachedTimezoneName[64] = "";
 RTC_DATA_ATTR char cachedTimezonePosix[96] = "";
 // RTC epoch of the last successful NTP synchronization.
 RTC_DATA_ATTR time_t lastNtpSyncTime = 0;
+// SHA-256 of the last image successfully driven to the panel.
+RTC_DATA_ATTR char displayedCalendarSignature[65] = "";
 
 // Remote MQTT diagnostics.
 esp_mqtt_client_handle_t mqttClient = nullptr;
@@ -193,6 +198,57 @@ esp_err_t displayImage(const char *url)
     board.display();
     displayedErrorSignature = 0;
 
+    return ESP_OK;
+}
+
+esp_err_t fetchCalendarSignature(
+    const char *url,
+    char *signature,
+    size_t signatureSize)
+{
+    if (url == nullptr || url[0] == '\0' || signatureSize < 65)
+    {
+        return ESP_ERR_EMANIFEST;
+    }
+
+    HTTPClient http;
+    http.setConnectTimeout(3000);
+    http.setTimeout(3000);
+    http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
+    if (!http.begin(url))
+    {
+        return ESP_ERR_EMANIFEST;
+    }
+
+    const int httpCode = http.GET();
+    if (httpCode != HTTP_CODE_OK)
+    {
+        http.end();
+        return ESP_ERR_EMANIFEST;
+    }
+
+    StaticJsonDocument<256> document;
+    DeserializationError error = deserializeJson(document, http.getStream());
+    http.end();
+    if (error)
+    {
+        return ESP_ERR_EMANIFEST;
+    }
+
+    const char *sha256 = document["sha256"];
+    if (sha256 == nullptr || strlen(sha256) != 64)
+    {
+        return ESP_ERR_EMANIFEST;
+    }
+    for (size_t i = 0; i < 64; ++i)
+    {
+        if (!isxdigit(static_cast<unsigned char>(sha256[i])))
+        {
+            return ESP_ERR_EMANIFEST;
+        }
+    }
+
+    snprintf(signature, signatureSize, "%s", sha256);
     return ESP_OK;
 }
 

--- a/src/lib.h
+++ b/src/lib.h
@@ -1,6 +1,7 @@
 #ifndef LIB_H
 #define LIB_H
 #include <Inkplate.h>
+#include <HTTPClient.h>
 #include <WiFi.h>
 #include <WiFiUdp.h>
 #include <cppQueue.h>
@@ -48,6 +49,7 @@
 #define ESP_ERR_ERRNO_BASE (0)
 #define ESP_ERR_EDRAW (1 + ESP_ERR_ERRNO_BASE) // Draw error
 #define ESP_ERR_ENTP (2 + ESP_ERR_ERRNO_BASE)  // NTP error
+#define ESP_ERR_EMANIFEST (3 + ESP_ERR_ERRNO_BASE) // Manifest error
 
 // Enum of log verbosity levels.
 #define LOG_CRIT 0
@@ -72,6 +74,8 @@ extern RTC_DATA_ATTR bool batteryLowWarningDisplayed;
 extern RTC_DATA_ATTR uint32_t displayedErrorSignature;
 // RTC epoch of the last successful NTP synchronization.
 extern RTC_DATA_ATTR time_t lastNtpSyncTime;
+// SHA-256 of the last image successfully driven to the panel.
+extern RTC_DATA_ATTR char displayedCalendarSignature[65];
 // Whether routine debug and informational messages should be sent over MQTT.
 extern bool mqttDebugEnabled;
 // The log message queue.
@@ -103,6 +107,19 @@ esp_err_t configureWiFi(const char *ssid, const char *pass, int retries);
   - ESP_ERR_EDRAW if downloading or drawing the image fails.
 */
 esp_err_t displayImage(const char *url);
+
+/**
+  Fetch the content signature for a rendered calendar output.
+
+  @param url manifest URL.
+  @param signature destination buffer for the 64-character SHA-256.
+  @param signatureSize destination buffer size.
+  @returns ESP_OK when a valid signature is read, otherwise ESP_ERR_EMANIFEST.
+*/
+esp_err_t fetchCalendarSignature(
+    const char *url,
+    char *signature,
+    size_t signatureSize);
 
 /**
   Stop MQTT and WiFi after delivering any outstanding diagnostics.

--- a/src/lib.h
+++ b/src/lib.h
@@ -180,6 +180,13 @@ esp_err_t configureTime(const char *ntpHost, const char *timezoneName);
 void sleep(const int sleepHours);
 
 /**
+  Enter deep sleep for a duration in seconds.
+
+  @param sleepSeconds number of seconds before the timer wakeup.
+*/
+void sleepForSeconds(const uint32_t sleepSeconds);
+
+/**
   Connect to a MQTT broker for remote diagnostic logging.
 
   @param broker the hostname of the MQTT broker.

--- a/src/lib.h
+++ b/src/lib.h
@@ -68,6 +68,10 @@ extern RTC_DATA_ATTR time_t lastBootTime;
 extern RTC_DATA_ATTR time_t lastSleepTime;
 // Whether the retained e-ink display already shows the critical battery warning.
 extern RTC_DATA_ATTR bool batteryLowWarningDisplayed;
+// Signature of the retained error screen, or zero after a successful refresh.
+extern RTC_DATA_ATTR uint32_t displayedErrorSignature;
+// RTC epoch of the last successful NTP synchronization.
+extern RTC_DATA_ATTR time_t lastNtpSyncTime;
 // Whether routine debug and informational messages should be sent over MQTT.
 extern bool mqttDebugEnabled;
 // The log message queue.

--- a/src/lib.h
+++ b/src/lib.h
@@ -160,13 +160,15 @@ String networkDiagnostics();
 void displayMessage(const char *msg);
 
 /**
-  Connect to an NTP server and synchronize the on-board real-time clock.
+  Configure local timezone rules and synchronize the on-board real-time clock
+  from NTP when the retained synchronization interval has elapsed or the RTC is
+  invalid.
 
   @param ntpHost the hostname of the NTP server (eg. pool.ntp.org).
   @param timezoneName the name of the timezone in Olson format (eg.
   Europe/Dublin)
   @returns the esp_err_t code:
-  - ESP_OK if successful.
+  - ESP_OK if the retained RTC is valid or synchronization succeeds.
   - ESP_ERR_ENTP if updating the NTP client fails.
 */
 esp_err_t configureTime(const char *ntpHost, const char *timezoneName);

--- a/src/src.ino
+++ b/src/src.ino
@@ -1,28 +1,7 @@
 #include <ArduinoJson.h>
-#include <ArduinoYaml.h>
-#include <StreamUtils.h>
 
+#include "config.h"
 #include "lib.h"
-
-#if defined(EMBEDDED_CONFIG)
-#include "embedded_config.h"
-#endif
-
-bool isMissingConfigValue(const char *value)
-{
-    return value == nullptr || value[0] == '\0';
-}
-
-void failConfig(const char *msg)
-{
-    log(LOG_ERROR, msg);
-    displayError("Config error", msg, configDiagnostics(CONFIG_SOURCE));
-    sleep(CONFIG_DEFAULT_CALENDAR_DAILY_REFRESH_INTERVAL);
-    while (true)
-    {
-        delay(1000);
-    }
-}
 
 void setup()
 {
@@ -73,136 +52,14 @@ void setup()
     // Init err state.
     esp_err_t err = ESP_OK;
 
-    StaticJsonDocument<768> doc;
-
-#if defined(EMBEDDED_CONFIG)
-    DeserializationError dse = deserializeYml(doc, EMBEDDED_CONFIG_YAML);
-#else
-    // SD mode uses the card only as a configuration source.
-    if (!board.sdCardInit())
+    StaticJsonDocument<CONFIG_YAML_DOCUMENT_CAPACITY> configDocument;
+    RuntimeConfig config;
+    if (!loadRuntimeConfig(configDocument, config))
     {
-        const char *errMsg = "SD card init failure";
-        log(LOG_ERROR, errMsg);
-        displayError("Storage error", errMsg);
-        sleep(CONFIG_DEFAULT_CALENDAR_DAILY_REFRESH_INTERVAL);
+        return;
     }
-
-    // Attempt to get config yaml file.
-    SdFat &sd = board.getSdFat();
-    File file = sd.open(CONFIG_FILE_PATH, FILE_READ);
-    if (!file)
-    {
-        const char *errMsg = "Failed to open config file";
-        logf(LOG_ERROR, errMsg);
-        displayError("Config error", errMsg, configDiagnostics(CONFIG_FILE_PATH));
-        sleep(CONFIG_DEFAULT_CALENDAR_DAILY_REFRESH_INTERVAL);
-    }
-
-    ReadBufferingStream bufferedFile(file, 64);
-    DeserializationError dse = deserializeYml(doc, bufferedFile);
-#endif
-
-    if (dse)
-    {
-        const char *errMsg = "Failed to load configuration";
-        logf(LOG_ERROR, "failed to deserialize YAML: %s", dse.c_str());
-        String diagnostics = configDiagnostics(CONFIG_SOURCE);
-        diagnostics = appendDiagnostic(diagnostics, "Parser: ", dse.c_str());
-        displayError("Config error", errMsg, diagnostics);
-        sleep(CONFIG_DEFAULT_CALENDAR_DAILY_REFRESH_INTERVAL);
-    }
-#if !defined(EMBEDDED_CONFIG)
-    file.close();
-    board.sdCardSleep();
-#endif
-
-    JsonObject displayCfg = doc["display"];
-    int displayRotation =
-        displayCfg["rotation"] | CONFIG_DEFAULT_DISPLAY_ROTATION;
-    if (displayRotation < 0 || displayRotation > 3)
-    {
-        failConfig("Invalid display.rotation");
-    }
-    board.setRotation(displayRotation);
-
-    // Assign config values.
-    JsonObject calendarCfg = doc["calendar"];
-    const char *calendarUrl = calendarCfg["url"];
-    int calendarRetries = calendarCfg["retries"] | 3;
-    const int calendarRefreshInterval =
-        calendarCfg["refresh_interval"] | CONFIG_DEFAULT_CALENDAR_DAILY_REFRESH_INTERVAL;
-
-    // Wifi config.
-    JsonObject wifiCfg = doc["wifi"];
-    const char *wifiSSID = wifiCfg["ssid"];
-    const char *wifiPass = wifiCfg["pass"] | "";
-    int wifiRetries = wifiCfg["retries"] | 6;
-
-    // NTP config.
-    const char *ntpHost = doc["ntp"]["host"];
-    const char *ntpTimezone = doc["ntp"]["timezone"];
-
-    // Optional remote diagnostic logging config.
-    JsonObject mqttLoggerCfg = doc["mqtt_logger"];
-    bool mqttLoggerEnabled = mqttLoggerCfg["enabled"] | false;
-    const char *mqttLoggerBroker = mqttLoggerCfg["broker"];
-    int mqttLoggerPort = mqttLoggerCfg["port"] | 1883;
-    const char *mqttLoggerClientID = mqttLoggerCfg["clientId"];
-    const char *mqttLoggerTopic = mqttLoggerCfg["topic"];
-    int mqttLoggerRetries = mqttLoggerCfg["retries"] | 3;
-    mqttDebugEnabled = mqttLoggerCfg["debug"] | false;
-
-    if (isMissingConfigValue(calendarUrl))
-    {
-        failConfig("Missing calendar.url");
-    }
-    if (calendarRefreshInterval <= 0)
-    {
-        failConfig("Invalid calendar.refresh_interval");
-    }
-    if (calendarRetries < 0)
-    {
-        failConfig("Invalid calendar.retries");
-    }
-    if (isMissingConfigValue(wifiSSID))
-    {
-        failConfig("Missing wifi.ssid");
-    }
-    if (wifiRetries < 0)
-    {
-        failConfig("Invalid wifi.retries");
-    }
-    if (isMissingConfigValue(ntpHost))
-    {
-        failConfig("Missing ntp.host");
-    }
-    if (isMissingConfigValue(ntpTimezone))
-    {
-        failConfig("Missing ntp.timezone");
-    }
-    if (mqttLoggerEnabled)
-    {
-        if (isMissingConfigValue(mqttLoggerBroker))
-        {
-            failConfig("Missing mqtt_logger.broker");
-        }
-        if (mqttLoggerPort <= 0)
-        {
-            failConfig("Invalid mqtt_logger.port");
-        }
-        if (isMissingConfigValue(mqttLoggerClientID))
-        {
-            failConfig("Missing mqtt_logger.clientId");
-        }
-        if (isMissingConfigValue(mqttLoggerTopic))
-        {
-            failConfig("Missing mqtt_logger.topic");
-        }
-        if (mqttLoggerRetries < 0)
-        {
-            failConfig("Invalid mqtt_logger.retries");
-        }
-    }
+    board.setRotation(config.displayRotation);
+    mqttDebugEnabled = config.mqttDebugEnabled;
 
     logTagged(
         LOG_INFO, "WAKE", "cause=%s firmware=%s",
@@ -228,7 +85,7 @@ void setup()
                     batteryDiagnostics(bvolt));
                 batteryLowWarningDisplayed = true;
             }
-            sleep(calendarRefreshInterval);
+            sleep(config.calendarRefreshInterval);
         }
 
         batteryLowWarningDisplayed = false;
@@ -239,22 +96,29 @@ void setup()
     }
 
     // Attempt to connect to WiFi.
-    err = configureWiFi(wifiSSID, wifiPass, wifiRetries);
+    err = configureWiFi(config.wifiSSID, config.wifiPass, config.wifiRetries);
     if (err == ESP_ERR_TIMEOUT)
     {
         const char *errMsg = "wifi connect timeout";
         log(LOG_ERROR, errMsg);
         String diagnostics = networkDiagnostics();
-        diagnostics = appendDiagnostic(diagnostics, "SSID: ", wifiSSID);
-        diagnostics = appendDiagnostic(diagnostics, "Retries configured: ", String(wifiRetries));
+        diagnostics = appendDiagnostic(diagnostics, "SSID: ", config.wifiSSID);
+        diagnostics = appendDiagnostic(
+            diagnostics,
+            "Retries configured: ",
+            String(config.wifiRetries));
         displayError("WiFi error", errMsg, diagnostics);
-        sleep(calendarRefreshInterval);
+        sleep(config.calendarRefreshInterval);
     }
 
-    if (mqttLoggerEnabled)
+    if (config.mqttLoggerEnabled)
     {
-        err = configureMQTT(mqttLoggerBroker, mqttLoggerPort, mqttLoggerTopic,
-                            mqttLoggerClientID, mqttLoggerRetries);
+        err = configureMQTT(
+            config.mqttLoggerBroker,
+            config.mqttLoggerPort,
+            config.mqttLoggerTopic,
+            config.mqttLoggerClientID,
+            config.mqttLoggerRetries);
         if (err != ESP_OK)
         {
             log(LOG_WARNING,
@@ -263,7 +127,7 @@ void setup()
     }
 
     // Attempt to synchronize clocks with network time.
-    err = configureTime(ntpHost, ntpTimezone);
+    err = configureTime(config.ntpHost, config.ntpTimezone);
     if (err != ESP_OK)
     {
         log(LOG_WARNING, "failed to synchronize RTC with network time");
@@ -291,25 +155,25 @@ void setup()
     {
         logf(LOG_DEBUG, "calendar refresh attempt #%d", attempts + 1);
 
-        err = displayImage(calendarUrl);
+        err = displayImage(config.calendarUrl);
         if (err != ESP_OK)
         {
             errMsg = "image display error";
             log(LOG_ERROR, errMsg);
             continue;
         }
-    } while (err != ESP_OK && ++attempts <= calendarRetries);
+    } while (err != ESP_OK && ++attempts <= config.calendarRetries);
 
     // E-ink retains the previous image, so a failed refresh should not replace
     // a valid forecast with an error screen.
     if (err != ESP_OK)
     {
         logf(LOG_ERROR, "%s after %d attempts", errMsg, attempts);
-        logf(LOG_ERROR, "calendar URL: %s", calendarUrl);
+        logf(LOG_ERROR, "calendar URL: %s", config.calendarUrl);
     }
 
     // Deep sleep until next refresh time
-    sleep(calendarRefreshInterval);
+    sleep(config.calendarRefreshInterval);
 }
 
 void loop() {}

--- a/src/src.ino
+++ b/src/src.ino
@@ -147,6 +147,32 @@ void setup()
              dateTime(lastSleepTime, RFC3339).c_str());
     }
 
+    char candidateSignature[65] = "";
+    bool refreshRequired = true;
+    if (config.calendarStatusUrl[0] != '\0')
+    {
+        err = fetchCalendarSignature(
+            config.calendarStatusUrl,
+            candidateSignature,
+            sizeof(candidateSignature));
+        if (err == ESP_OK &&
+            strcmp(candidateSignature, displayedCalendarSignature) == 0)
+        {
+            logTagged(LOG_INFO, "REFRESH", "status=unchanged");
+            refreshRequired = false;
+        }
+        else if (err != ESP_OK)
+        {
+            log(LOG_WARNING,
+                "calendar status unavailable; falling back to image refresh");
+        }
+    }
+
+    if (!refreshRequired)
+    {
+        sleep(config.calendarRefreshInterval);
+    }
+
     // Reset err state.
     err = ESP_FAIL;
     const char *errMsg;
@@ -161,6 +187,14 @@ void setup()
             errMsg = "image display error";
             log(LOG_ERROR, errMsg);
             continue;
+        }
+        if (candidateSignature[0] != '\0')
+        {
+            snprintf(
+                displayedCalendarSignature,
+                sizeof(displayedCalendarSignature),
+                "%s",
+                candidateSignature);
         }
     } while (err != ESP_OK && ++attempts <= config.calendarRetries);
 

--- a/src/src.ino
+++ b/src/src.ino
@@ -173,19 +173,19 @@ void setup()
         sleep(config.calendarRefreshInterval);
     }
 
-    // Reset err state.
+    // Limit radio-on retries to one immediate retry. Further recovery happens
+    // after a short deep-sleep interval.
     err = ESP_FAIL;
-    const char *errMsg;
+    const int maxAttempts = config.calendarRetries > 0 ? 2 : 1;
     int attempts = 0;
-    do
+    for (; attempts < maxAttempts; ++attempts)
     {
         logf(LOG_DEBUG, "calendar refresh attempt #%d", attempts + 1);
 
         err = displayImage(config.calendarUrl);
         if (err != ESP_OK)
         {
-            errMsg = "image display error";
-            log(LOG_ERROR, errMsg);
+            log(LOG_ERROR, "image display error");
             continue;
         }
         if (candidateSignature[0] != '\0')
@@ -196,14 +196,17 @@ void setup()
                 "%s",
                 candidateSignature);
         }
-    } while (err != ESP_OK && ++attempts <= config.calendarRetries);
+        break;
+    }
 
     // E-ink retains the previous image, so a failed refresh should not replace
     // a valid forecast with an error screen.
     if (err != ESP_OK)
     {
-        logf(LOG_ERROR, "%s after %d attempts", errMsg, attempts);
+        logf(LOG_ERROR, "image display error after %d attempts", attempts);
         logf(LOG_ERROR, "calendar URL: %s", config.calendarUrl);
+        sleepForSeconds(
+            static_cast<uint32_t>(config.calendarRetryIntervalMinutes) * 60UL);
     }
 
     // Deep sleep until next refresh time

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -13,6 +13,52 @@ SPEC.loader.exec_module(install_server)
 
 
 class InstallerCopyTests(unittest.TestCase):
+    def test_weather_choices_match_registered_forecast_providers(self):
+        choices = install_server.weather_provider_choices()
+
+        self.assertEqual(
+            {name for name, _ in choices},
+            set(install_server.FORECAST_PROVIDERS),
+        )
+
+    def test_rendered_config_uses_runtime_output_defaults(self):
+        answers = {
+            "port": 8080,
+            "refresh_hours": 3,
+            "weather_service": "openweathermapv3",
+            "num_hourly_forecasts": 6,
+            "metric": True,
+            "netatmo_enabled": False,
+            "location": "Landry, FR",
+            "mqtt_weather_enabled": False,
+            "mqtt_weather_broker": "",
+            "mqtt_weather_port": 1883,
+            "mqtt_weather_base_topic": "",
+            "mqtt_diagnostics_enabled": False,
+            "mqtt_diagnostics_broker": "",
+            "mqtt_diagnostics_port": 1883,
+            "mqtt_diagnostics_topic": "",
+        }
+
+        config = install_server.render_config(answers, mode="docker")
+
+        self.assertIn(
+            f"  default: {install_server.DEFAULT_OUTPUT_PROFILE}",
+            config,
+        )
+        self.assertIn(
+            f"      renderer: {install_server.DEFAULT_RENDERER}",
+            config,
+        )
+        self.assertIn(
+            f"      width: {install_server.DEFAULT_IMAGE_WIDTH}",
+            config,
+        )
+        self.assertIn(
+            f"      height: {install_server.DEFAULT_IMAGE_HEIGHT}",
+            config,
+        )
+
     def test_preserves_committed_png_assets_and_ignores_generated_images(self):
         with tempfile.TemporaryDirectory() as temporary_dir:
             root = pathlib.Path(temporary_dir)


### PR DESCRIPTION
## Summary

Establish explicit forecast and realtime weather provider interfaces, centralize provider construction, expand Netatmo realtime data, and extract firmware configuration loading from `setup()`.

Closes #234.
Closes #235.

## Weather provider layer

- add `ForecastProvider` and `RealtimeProvider` contracts
- add a lazy provider registry/factory in `server/weather/providers.py`
- centralize supported, removed, and unknown provider handling
- remove the legacy `openweathermap` v2 name; OpenWeatherMap support is now v3 and v4 only
- keep configuration failures at the producer process boundary instead of calling `sys.exit()` from helpers
- retain migration support for the old `current_temperature` config key while making `current_conditions` the documented form
- normalize OpenWeatherMap hourly wind fields to `value`/`unit`

## Netatmo realtime conditions

- retain temperature override support
- add humidity
- add optional wind speed, gust, and direction via `wind_module_id`
- add optional current, one-hour, and 24-hour rain measurements via `rain_module_id`
- expose normalized optional values through the existing API and MQTT current snapshot
- update installer prompts, environment variables, Compose configuration, examples, and documentation

## Firmware design and power behavior

- move YAML loading, extraction, and validation into `src/config.cpp`
- introduce an explicit `RuntimeConfig` structure
- name and document the 768-byte JSON document and 64-byte SD stream capacities
- preserve the existing validation messages
- preserve explicit file closure before SD card sleep
- preserve RTC-retained state
- preserve startup order: battery is checked before Wi-Fi or other network activity
- add no network work, retries, delays, or display refreshes

## Validation

- 58 server tests pass
- 4 root installer/version tests pass
- SD-card firmware build passes
  - flash: 1,165,629 bytes (37%)
  - global RAM: 67,576 bytes (20%)
- embedded-config firmware build passes
  - flash: 1,160,869 bytes (36%)
  - global RAM: 67,520 bytes (20%)
- example YAML files parse successfully
- `git diff --check`
- Python compilation checks pass